### PR TITLE
Add CommandListener.getPriority()

### DIFF
--- a/implementation/src/main/java/io/smallrye/faulttolerance/CommandListener.java
+++ b/implementation/src/main/java/io/smallrye/faulttolerance/CommandListener.java
@@ -15,15 +15,21 @@
  */
 package io.smallrye.faulttolerance;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 
 /**
- * This listener can be used to perfom actions before and after a Hystrix command that wraps a FT operation is executed.
+ * Any bean which implements this listener can be used to perfom actions before and after a Hystrix command that wraps a FT operation is executed. The bean
+ * should be {@link Dependent} or {@link ApplicationScoped}. Note that a contextual instance of this bean is obtained for each command execution.
+ *
  *
  * @author Martin Kouba
- * @see SimpleCommand#execute()
+ * @see SimpleCommand#run()
+ * @see CommandListenersProvider
  */
-public interface CommandListener {
+public interface CommandListener extends Comparable<CommandListener> {
 
     /**
      * Should not throw an exception.
@@ -39,6 +45,21 @@ public interface CommandListener {
      * @param operation The fault tolerance operation metadata
      */
     default void afterExecution(FaultToleranceOperation operation) {
+    }
+
+    /**
+     * {@link #beforeExecution(FaultToleranceOperation)} of listeners with smaller priority values are called first.
+     * {@link #afterExecution(FaultToleranceOperation)} is invoked in reverse order.
+     *
+     * @return the priority
+     */
+    default int getPriority() {
+        return 1000;
+    }
+
+    @Override
+    default int compareTo(CommandListener o) {
+        return Integer.compare(getPriority(), o.getPriority());
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/faulttolerance/CommandListenersProvider.java
+++ b/implementation/src/main/java/io/smallrye/faulttolerance/CommandListenersProvider.java
@@ -15,25 +15,24 @@
  */
 package io.smallrye.faulttolerance;
 
+import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
-import org.eclipse.microprofile.faulttolerance.FallbackHandler;
-
-import io.smallrye.faulttolerance.config.FaultToleranceOperation;
-
 /**
- * An integrator is allowed to provide a custom implementation of {@link FallbackHandlerProvider}. The bean should be {@link Dependent}, must be marked as
- * alternative and selected globally for an application.
+ * Makes it possible to wrap/enhance the command listener instances.
  *
- * @author Martin Kouba
+ * <p>
+ * An integrator is allowed to provide a custom implementation of {@link CommandListenersProvider}. The bean should be {@link Dependent}, must be marked as
+ * alternative and selected globally for an application.
+ * </p>
  */
-public interface FallbackHandlerProvider {
+public interface CommandListenersProvider {
 
     /**
      *
-     * @param operation Fault tolerance operation
-     * @return a new fallback handler or {@code null}
+     * @return a sorted list of command listeners or {@code null} if no listeners are available
      */
-    <T> FallbackHandler<T> get(FaultToleranceOperation operation);
+    List<CommandListener> getCommandListeners();
 
 }

--- a/implementation/src/main/java/io/smallrye/faulttolerance/DefaultCommandListenersProvider.java
+++ b/implementation/src/main/java/io/smallrye/faulttolerance/DefaultCommandListenersProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.faulttolerance;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+/**
+ * Default implementation of {@link CommandListenersProvider}. Note that dependent listeners are not destroyed automatically.
+ *
+ * @author mkouba
+ */
+@ApplicationScoped
+public class DefaultCommandListenersProvider implements CommandListenersProvider {
+
+    @Inject
+    Instance<CommandListener> listeners;
+
+    public List<CommandListener> getCommandListeners() {
+        if (listeners.isUnsatisfied()) {
+            return null;
+        } else {
+            return StreamSupport.stream(listeners.spliterator(), false).sorted().collect(Collectors.toList());
+        }
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/faulttolerance/DefaultFallbackHandlerProvider.java
+++ b/implementation/src/main/java/io/smallrye/faulttolerance/DefaultFallbackHandlerProvider.java
@@ -12,13 +12,8 @@ import io.smallrye.faulttolerance.config.FallbackConfig;
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 
 /**
- * 
- * <p>
- * An integrator is allowed to provide a custom implementation of {@link FallbackHandlerProvider}. The bean should be {@link Dependent}, must be marked as
- * alternative and selected globally for an application.
- * </p>
- * 
- * 
+ * Default implementation of {@link FallbackHandlerProvider}.
+ *
  * @author Martin Kouba
  */
 @Dependent

--- a/implementation/src/main/java/io/smallrye/faulttolerance/DefaultFaultToleranceOperationProvider.java
+++ b/implementation/src/main/java/io/smallrye/faulttolerance/DefaultFaultToleranceOperationProvider.java
@@ -25,12 +25,10 @@ import javax.inject.Inject;
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 
 /**
- * <p>
- * An integrator is allowed to provide a custom implementation of {@link FaultToleranceOperationProvider}. The bean should be {@link Dependent}, must be marked
- * as alternative and selected globally for an application.
- * </p>
+ * Default implementation of {@link FaultToleranceOperationProvider}.
  *
  * @author Martin Kouba
+ * @see FaultToleranceOperationProvider
  */
 @Dependent
 public class DefaultFaultToleranceOperationProvider implements FaultToleranceOperationProvider {

--- a/implementation/src/main/java/io/smallrye/faulttolerance/DefaultHystrixConcurrencyStrategy.java
+++ b/implementation/src/main/java/io/smallrye/faulttolerance/DefaultHystrixConcurrencyStrategy.java
@@ -37,7 +37,7 @@ import com.netflix.hystrix.strategy.properties.HystrixProperty;
  * The default concurrency strategy using the managed version of {@link ThreadFactory}.
  *
  * <p>
- * A user is allowed to provide a custom implementation of {@link HystrixConcurrencyStrategy}. The bean should be {@link Dependent}, must be marked as
+ * An integrator or an application is allowed to provide a custom implementation of {@link HystrixConcurrencyStrategy}. The bean should be {@link Dependent}, must be marked as
  * alternative and selected globally for an application.
  * </p>
  *

--- a/implementation/src/main/java/io/smallrye/faulttolerance/FaultToleranceOperationProvider.java
+++ b/implementation/src/main/java/io/smallrye/faulttolerance/FaultToleranceOperationProvider.java
@@ -17,9 +17,13 @@ package io.smallrye.faulttolerance;
 
 import java.lang.reflect.Method;
 
+import javax.enterprise.context.Dependent;
+
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 
 /**
+ * An integrator is allowed to provide a custom implementation of {@link FaultToleranceOperationProvider}. The bean should be {@link Dependent}, must be marked
+ * as alternative and selected globally for an application.
  *
  * @author Martin Kouba
  */

--- a/implementation/src/main/java/io/smallrye/faulttolerance/HystrixExtension.java
+++ b/implementation/src/main/java/io/smallrye/faulttolerance/HystrixExtension.java
@@ -72,6 +72,7 @@ public class HystrixExtension implements Extension {
         bbd.addAnnotatedType(bm.createAnnotatedType(DefaultHystrixConcurrencyStrategy.class), DefaultHystrixConcurrencyStrategy.class.getName());
         bbd.addAnnotatedType(bm.createAnnotatedType(DefaultFaultToleranceOperationProvider.class), DefaultFaultToleranceOperationProvider.class.getName());
         bbd.addAnnotatedType(bm.createAnnotatedType(DefaultFallbackHandlerProvider.class), DefaultFallbackHandlerProvider.class.getName());
+        bbd.addAnnotatedType(bm.createAnnotatedType(DefaultCommandListenersProvider.class), DefaultCommandListenersProvider.class.getName());
     }
 
     /**

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/command/listener/WeldCommandListenersProvider.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/command/listener/WeldCommandListenersProvider.java
@@ -1,0 +1,64 @@
+package io.smallrye.faulttolerance.command.listener;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
+import org.jboss.weld.inject.WeldInstance;
+import org.jboss.weld.inject.WeldInstance.Handler;
+
+import io.smallrye.faulttolerance.CommandListener;
+import io.smallrye.faulttolerance.DefaultCommandListenersProvider;
+import io.smallrye.faulttolerance.config.FaultToleranceOperation;
+
+@Priority(1)
+@Alternative
+@ApplicationScoped
+public class WeldCommandListenersProvider extends DefaultCommandListenersProvider {
+
+    @Inject
+    WeldInstance<CommandListener> listeners;
+
+    @Override
+    public List<CommandListener> getCommandListeners() {
+        if (listeners.isUnsatisfied()) {
+            return null;
+        }
+        List<CommandListener> commandListeners = new ArrayList<>();
+        for (Handler<CommandListener> handler : listeners.handlers()) {
+            if (Dependent.class.equals(handler.getBean().getScope())) {
+                // Wrap dependent listener
+                commandListeners.add(new CommandListener() {
+
+                    @Override
+                    public void beforeExecution(FaultToleranceOperation operation) {
+                        handler.get().beforeExecution(operation);
+                    }
+
+                    @Override
+                    public void afterExecution(FaultToleranceOperation operation) {
+                        handler.get().afterExecution(operation);
+                        handler.destroy();
+                    }
+
+                    @Override
+                    public int getPriority() {
+                        return handler.get().getPriority();
+                    }
+
+                });
+            } else {
+                commandListeners.add(handler.get());
+            }
+        }
+        Collections.sort(commandListeners);
+        return commandListeners;
+    }
+
+}


### PR DESCRIPTION
- also introduce CommandListenersProvider to work around limitation in
CDI API - we need to destroy dependent CommandListener instances after
execution is finished (this will allow integrators to leverage
non-portable APIs)