### PR TITLE
Update to MP Metrics 2.1.0 and SRye Metrics 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,12 +39,12 @@
     <version.javax.interceptor-api>1.2.2</version.javax.interceptor-api>
     <version.mp-fault-tolerance>2.0.2</version.mp-fault-tolerance>
     <version.microprofile-config-api>1.3</version.microprofile-config-api>
-    <version.microprofile-metrics-api>2.0.2</version.microprofile-metrics-api>
+    <version.microprofile-metrics-api>2.1.0</version.microprofile-metrics-api>
     <version.slf4j-simple>1.7.28</version.slf4j-simple>
     <!-- smallrye-config is purely used for testing -->
     <version.smallrye-config>1.3.9</version.smallrye-config>
     <!-- smallrye-metrics is purely used for testing -->
-    <version.smallrye-metrics>2.1.5</version.smallrye-metrics>
+    <version.smallrye-metrics>2.2.0</version.smallrye-metrics>
     <version.opentracing>0.31.0</version.opentracing>
 
     <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>

--- a/testsuite/tck/src/test/tck-suite.xml
+++ b/testsuite/tck/src/test/tck-suite.xml
@@ -34,6 +34,20 @@
           <exclude name="testTimeout"/>
         </methods>
       </class>
+
+      <!-- https://github.com/eclipse/microprofile-fault-tolerance/issues/464 -->
+      <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest">
+        <methods>
+          <exclude name="bulkheadMetricAsyncTest"/>
+          <exclude name="bulkheadMetricRejectionTest"/>
+          <exclude name="bulkheadMetricTest"/>
+        </methods>
+      </class>
+      <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest">
+        <methods>
+          <exclude name="testAllMetrics"/>
+        </methods>
+      </class>
     </classes>
   </test>
 


### PR DESCRIPTION
 - Exclude failing MP FT TCK tests that have binary incompatibility with MP Metrics API class