### PR TITLE
Fixes #138: testWaitingQueue(io.smallrye.faulttolerance.bulkhead.Bulk…

### DIFF
--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/bulkhead/BulkheadTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/bulkhead/BulkheadTest.java
@@ -59,7 +59,7 @@ public class BulkheadTest {
         for (int i = 0; i < loop; i++) {
             futures.add(pingService.ping(startLatch, endLatch));
         }
-        assertTrue(startLatch.await(500L, TimeUnit.MILLISECONDS));
+        assertTrue(startLatch.await(1000L, TimeUnit.MILLISECONDS));
         Thread.sleep(500L);
         // Next invocation should not make it due to BulkheadException
         try {


### PR DESCRIPTION
…headTest) is flaky