### PR TITLE
workaround for MP FT TCK issue in TimeoutMetricTest

### DIFF
--- a/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -26,6 +26,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 /**
  *
@@ -61,6 +62,15 @@ public class FaultToleranceApplicationArchiveProcessor implements ApplicationArc
 
         if (!applicationArchive.contains("META-INF/beans.xml")) {
             applicationArchive.add(EmptyAsset.INSTANCE, "META-INF/beans.xml");
+        }
+
+        if (applicationArchive instanceof WebArchive
+                && applicationArchive.contains("META-INF/microprofile-config.properties")
+                && !applicationArchive.contains("WEB-INF/classes/META-INF/microprofile-config.properties")) {
+            // workaround for https://github.com/eclipse/microprofile-fault-tolerance/pull/495
+            // this entire `if` should be removed when that PR is merged and MP FT released
+            applicationArchive.move("META-INF/microprofile-config.properties",
+                    "WEB-INF/classes/META-INF/microprofile-config.properties");
         }
 
         LOGGER.info("Added additional resources to " + applicationArchive.toString(true));


### PR DESCRIPTION
See https://github.com/eclipse/microprofile-fault-tolerance/pull/495
for more info. When that PR is merged, this commit shall be reverted.