### PR TITLE
fix CompletionStageTimeout threading

### DIFF
--- a/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagatingScheduledExecutorService.java
+++ b/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagatingScheduledExecutorService.java
@@ -1,0 +1,127 @@
+package io.smallrye.faulttolerance.propagation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.microprofile.context.ThreadContext;
+
+final class ContextPropagatingScheduledExecutorService implements ScheduledExecutorService {
+    private final ThreadContext threadContext;
+    private final ScheduledExecutorService delegate;
+
+    ContextPropagatingScheduledExecutorService(ThreadContext threadContext, ScheduledExecutorService delegate) {
+        this.threadContext = threadContext;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate.schedule(threadContext.contextualRunnable(command), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return delegate.schedule(threadContext.contextualCallable(callable), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return delegate.scheduleAtFixedRate(threadContext.contextualRunnable(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return delegate.scheduleWithFixedDelay(threadContext.contextualRunnable(command), initialDelay, delay, unit);
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(threadContext.contextualCallable(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(threadContext.contextualRunnable(task), result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(threadContext.contextualRunnable(task));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        List<Callable<T>> contextualTasks = new ArrayList<>(tasks.size());
+        for (Callable<T> task : tasks) {
+            contextualTasks.add(threadContext.contextualCallable(task));
+        }
+        return delegate.invokeAll(contextualTasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        List<Callable<T>> contextualTasks = new ArrayList<>(tasks.size());
+        for (Callable<T> task : tasks) {
+            contextualTasks.add(threadContext.contextualCallable(task));
+        }
+        return delegate.invokeAll(contextualTasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        List<Callable<T>> contextualTasks = new ArrayList<>(tasks.size());
+        for (Callable<T> task : tasks) {
+            contextualTasks.add(threadContext.contextualCallable(task));
+        }
+        return delegate.invokeAny(contextualTasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        List<Callable<T>> contextualTasks = new ArrayList<>(tasks.size());
+        for (Callable<T> task : tasks) {
+            contextualTasks.add(threadContext.contextualCallable(task));
+        }
+        return delegate.invokeAny(contextualTasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(threadContext.contextualRunnable(command));
+    }
+}

--- a/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagationExecutorFactory.java
+++ b/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagationExecutorFactory.java
@@ -5,6 +5,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
 
 import io.smallrye.context.SmallRyeManagedExecutor;
 import io.smallrye.faulttolerance.ExecutorFactory;
@@ -27,7 +28,9 @@ public class ContextPropagationExecutorFactory implements ExecutorFactory {
 
     @Override
     public ScheduledExecutorService createTimeoutExecutor(int size) {
-        return Executors.newScheduledThreadPool(size);
+        ThreadContext threadContext = ThreadContext.builder().build();
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(size);
+        return new ContextPropagatingScheduledExecutorService(threadContext, executor);
     }
 
     @Override

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timeout/CompletionStageTimeout.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timeout/CompletionStageTimeout.java
@@ -1,28 +1,37 @@
 package io.smallrye.faulttolerance.core.timeout;
 
 import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static io.smallrye.faulttolerance.core.util.Preconditions.checkNotNull;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
 import io.smallrye.faulttolerance.core.InvocationContext;
 
 public class CompletionStageTimeout<V> extends Timeout<CompletionStage<V>> {
+    // in the real world (outside of tests), this must be the same executor that is used to execute the guarded method
+    private final ExecutorService originalExecutor;
+
     // TODO only for unit tests, they need to be rewritten to always run CompletionStage* strategies asynchronously
     private final boolean interruptCurrentThread;
 
     public CompletionStageTimeout(FaultToleranceStrategy<CompletionStage<V>> delegate, String description, long timeoutInMillis,
-            TimeoutWatcher watcher, MetricsRecorder metricsRecorder) {
+            TimeoutWatcher watcher, ExecutorService originalExecutor, MetricsRecorder metricsRecorder) {
         super(delegate, description, timeoutInMillis, watcher, metricsRecorder);
+        this.originalExecutor = checkNotNull(originalExecutor, "original executor must be set");
         this.interruptCurrentThread = false;
     }
 
     // only for tests
     CompletionStageTimeout(FaultToleranceStrategy<CompletionStage<V>> delegate, String description, long timeoutInMillis,
-            TimeoutWatcher watcher, MetricsRecorder metricsRecorder, boolean interruptCurrentThread) {
+            TimeoutWatcher watcher, ExecutorService originalExecutor, MetricsRecorder metricsRecorder,
+            boolean interruptCurrentThread) {
         super(delegate, description, timeoutInMillis, watcher, metricsRecorder);
+        this.originalExecutor = originalExecutor;
         this.interruptCurrentThread = interruptCurrentThread;
     }
 
@@ -30,10 +39,25 @@ public class CompletionStageTimeout<V> extends Timeout<CompletionStage<V>> {
     public CompletionStage<V> apply(InvocationContext<CompletionStage<V>> ctx) {
         CompletableFuture<V> result = new CompletableFuture<>();
 
+        long start = System.nanoTime();
+
+        AtomicBoolean completedWithTimeout = new AtomicBoolean(false);
         AtomicReference<CompletionStage<V>> runningTaskRef = new AtomicReference<>();
         Thread threadToInterrupt = interruptCurrentThread ? Thread.currentThread() : null;
         TimeoutExecution timeoutExecution = new TimeoutExecution(threadToInterrupt, timeoutInMillis, () -> {
-            result.completeExceptionally(timeoutException(description));
+            if (completedWithTimeout.compareAndSet(false, true)) {
+                long end = System.nanoTime();
+                metricsRecorder.timeoutTimedOut(end - start);
+
+                // completing the `result` means dependent stages (such as subsequent retry attempts, or fallback)
+                // run immediately on the "current" thread
+                // if we completed the `result` on the timeout watcher thread, it would mean arbitrary code
+                // could execute on the timeout watcher thread, which is wrong
+                originalExecutor.submit(() -> {
+                    result.completeExceptionally(timeoutException(description));
+                });
+            }
+
             CompletionStage<V> runningTask = runningTaskRef.get();
             if (runningTask != null) {
                 // we pass `null` to the `TimeoutExecution` because we can't know in advance which thread to interrupt
@@ -42,7 +66,6 @@ public class CompletionStageTimeout<V> extends Timeout<CompletionStage<V>> {
             }
         });
         TimeoutWatch watch = watcher.schedule(timeoutExecution);
-        long start = System.nanoTime();
 
         CompletionStage<V> originalResult;
         try {
@@ -64,8 +87,10 @@ public class CompletionStageTimeout<V> extends Timeout<CompletionStage<V>> {
             long end = System.nanoTime();
 
             if (timeoutExecution.hasTimedOut()) {
-                metricsRecorder.timeoutTimedOut(end - start);
-                result.completeExceptionally(timeoutException(description));
+                if (completedWithTimeout.compareAndSet(false, true)) {
+                    metricsRecorder.timeoutTimedOut(end - start);
+                    result.completeExceptionally(timeoutException(description));
+                }
             } else if (exception != null) {
                 metricsRecorder.timeoutFailed(end - start);
                 result.completeExceptionally(exception);

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/RealWorldCompletionStageTimeoutTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/RealWorldCompletionStageTimeoutTest.java
@@ -42,7 +42,8 @@ public class RealWorldCompletionStageTimeoutTest {
 
     private ScheduledExecutorService executor;
     private ScheduledExecutorTimeoutWatcher watcher;
-    private ExecutorService taskExecutor;
+
+    private ExecutorService timeoutActionExecutor;
 
     private Stopwatch stopwatch = new SystemStopwatch();
 
@@ -51,25 +52,24 @@ public class RealWorldCompletionStageTimeoutTest {
         executor = Executors.newSingleThreadScheduledExecutor();
         watcher = new ScheduledExecutorTimeoutWatcher(executor);
 
-        taskExecutor = Executors.newSingleThreadExecutor();
+        timeoutActionExecutor = Executors.newSingleThreadExecutor();
     }
 
     @After
     public void tearDown() throws InterruptedException {
         executor.shutdownNow();
-        taskExecutor.shutdownNow();
+        timeoutActionExecutor.shutdownNow();
 
         executor.awaitTermination(1, TimeUnit.SECONDS);
-        taskExecutor.awaitTermination(1, TimeUnit.SECONDS);
+        timeoutActionExecutor.awaitTermination(1, TimeUnit.SECONDS);
     }
 
     @Test
     public void shouldReturnRightAway() throws Exception {
         RunningStopwatch runningStopwatch = stopwatch.start();
 
-        FaultToleranceStrategy<CompletionStage<String>> timeout = new CompletionStageTimeout<>(
-                invocation(),
-                "completion stage timeout", TIMEOUT, watcher, null);
+        FaultToleranceStrategy<CompletionStage<String>> timeout = new CompletionStageTimeout<>(invocation(),
+                "completion stage timeout", TIMEOUT, watcher, timeoutActionExecutor, null);
 
         assertThat(timeout.apply(new InvocationContext<>(() -> {
             Thread.sleep(SLEEP_TIME);
@@ -82,9 +82,8 @@ public class RealWorldCompletionStageTimeoutTest {
     public void shouldPropagateMethodError() throws Exception {
         RunningStopwatch runningStopwatch = stopwatch.start();
 
-        FaultToleranceStrategy<CompletionStage<String>> timeout = new CompletionStageTimeout<>(
-                invocation(),
-                "completion stage timeout", TIMEOUT, watcher, null);
+        FaultToleranceStrategy<CompletionStage<String>> timeout = new CompletionStageTimeout<>(invocation(),
+                "completion stage timeout", TIMEOUT, watcher, timeoutActionExecutor, null);
 
         assertThatThrownBy(timeout.apply(new InvocationContext<>(() -> {
             Thread.sleep(SLEEP_TIME);
@@ -99,9 +98,8 @@ public class RealWorldCompletionStageTimeoutTest {
     public void shouldPropagateCompletionStageError() throws Exception {
         RunningStopwatch runningStopwatch = stopwatch.start();
 
-        FaultToleranceStrategy<CompletionStage<String>> timeout = new CompletionStageTimeout<>(
-                invocation(),
-                "completion stage timeout", TIMEOUT, watcher, null);
+        FaultToleranceStrategy<CompletionStage<String>> timeout = new CompletionStageTimeout<>(invocation(),
+                "completion stage timeout", TIMEOUT, watcher, timeoutActionExecutor, null);
 
         assertThatThrownBy(timeout.apply(new InvocationContext<>(() -> {
             Thread.sleep(SLEEP_TIME);
@@ -116,9 +114,8 @@ public class RealWorldCompletionStageTimeoutTest {
     public void shouldTimeOut() throws Exception {
         RunningStopwatch runningStopwatch = stopwatch.start();
 
-        FaultToleranceStrategy<CompletionStage<String>> timeout = new CompletionStageTimeout<>(
-                invocation(),
-                "completion stage timeout", SLEEP_TIME, watcher, null, true);
+        FaultToleranceStrategy<CompletionStage<String>> timeout = new CompletionStageTimeout<>(invocation(),
+                "completion stage timeout", SLEEP_TIME, watcher, timeoutActionExecutor, null, true);
 
         assertThatThrownBy(timeout.apply(new InvocationContext<>(() -> {
             Thread.sleep(TIMEOUT);

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceInterceptor.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceInterceptor.java
@@ -229,6 +229,7 @@ public class FaultToleranceInterceptor {
             result = new CompletionStageTimeout<>(result, "Timeout[" + point.name() + "]",
                     timeoutMs,
                     new ScheduledExecutorTimeoutWatcher(timeoutExecutor),
+                    asyncExecutor,
                     collector);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
         <artifactId>opentracing-mock</artifactId>
         <version>${version.opentracing}</version>
       </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-util</artifactId>
+        <version>${version.opentracing}</version>
+        <type>test-jar</type>
+      </dependency>
 
       <dependency>
         <groupId>io.smallrye.config</groupId>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -66,6 +66,11 @@
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+            <type>test-jar</type>
+        </dependency>
 
         <dependency>
             <groupId>io.smallrye.config</groupId>

--- a/testsuite/integration/src/test/java/io/smallrye/faulttolerance/tracing/TracingContextPropagationTest.java
+++ b/testsuite/integration/src/test/java/io/smallrye/faulttolerance/tracing/TracingContextPropagationTest.java
@@ -23,12 +23,14 @@ import java.util.concurrent.ExecutionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.opentracing.Scope;
 import io.opentracing.mock.MockSpan;
+import io.opentracing.util.GlobalTracerTestUtil;
 import io.smallrye.faulttolerance.TestArchive;
 
 /**
@@ -46,6 +48,11 @@ public class TracingContextPropagationTest {
     @Before
     public void cleanUp() {
         Service.mockTracer.reset();
+    }
+
+    @AfterClass
+    public static void reset() {
+        GlobalTracerTestUtil.resetGlobalTracer();
     }
 
     @Test

--- a/testsuite/integration/src/test/java/io/smallrye/faulttolerance/tracing/stress/Service.java
+++ b/testsuite/integration/src/test/java/io/smallrye/faulttolerance/tracing/stress/Service.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.faulttolerance.tracing.stress;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.GlobalTracer;
+
+public class Service {
+    public static MockTracer tracer = new MockTracer();
+
+    static {
+        GlobalTracer.register(tracer);
+    }
+
+    // intentionally low timeout value to stress the implementation
+    @Fallback(fallbackMethod = "fallback")
+    @Timeout(value = 1L)
+    @Retry(delay = 1L, maxRetries = 2)
+    @Asynchronous
+    public CompletionStage<String> hello() {
+        tracer.buildSpan("hello").start().finish();
+        throw new RuntimeException();
+    }
+
+    public CompletionStage<String> fallback() {
+        tracer.buildSpan("fallback").start().finish();
+        return completedFuture("fallback");
+    }
+}

--- a/testsuite/integration/src/test/java/io/smallrye/faulttolerance/tracing/stress/TracingContextPropagationStressTest.java
+++ b/testsuite/integration/src/test/java/io/smallrye/faulttolerance/tracing/stress/TracingContextPropagationStressTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.faulttolerance.tracing.stress;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.util.GlobalTracerTestUtil;
+import io.smallrye.faulttolerance.TestArchive;
+
+@RunWith(Arquillian.class)
+public class TracingContextPropagationStressTest {
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return TestArchive.createBase(TracingContextPropagationStressTest.class)
+                .addPackage(TracingContextPropagationStressTest.class.getPackage());
+    }
+
+    @AfterClass
+    public static void reset() {
+        GlobalTracerTestUtil.resetGlobalTracer();
+    }
+
+    @Test
+    public void test(Service service) throws ExecutionException, InterruptedException {
+        // 100 iterations so that the test doesn't run way too long
+        for (int i = 0; i < 100; i++) {
+            Service.tracer.reset();
+            doTest(service);
+        }
+    }
+
+    private void doTest(Service service) throws ExecutionException, InterruptedException {
+        try (Scope ignored = Service.tracer.buildSpan("parent").startActive(true)) {
+            assertEquals("fallback", service.hello().toCompletableFuture().get());
+        }
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(5, Service.tracer.finishedSpans().size());
+        });
+
+        List<MockSpan> spans = Service.tracer.finishedSpans();
+        for (MockSpan mockSpan : spans) {
+            assertEquals(spans.get(0).context().traceId(), mockSpan.context().traceId());
+        }
+        assertEquals("hello", spans.get(0).operationName());
+        assertEquals("hello", spans.get(1).operationName());
+        assertEquals("hello", spans.get(2).operationName());
+        assertEquals("fallback", spans.get(3).operationName());
+        assertEquals("parent", spans.get(4).operationName());
+    }
+}


### PR DESCRIPTION
This commit fixes asynchronous (`CompletionStage`-based) timeout
threading behavior. Originally, when timeout occured, the timeout
watcher thread would complete the `CompletionStage`, which would
immediately result in subsequent tasks ("dependent stages") being
run. They would, however, run on the timeout watcher thread, which
is wrong. In this commit, we make sure that the `CompletionStage`
is completed on a thread from the original thread pool.

To make this all work together with Context Propagation, this commit
also lets the timeout watcher thread pool propagate contexts. This
happens twice. First, when the timeout action is being executed,
context from original thread is propagated to the timeout watcher
thread. Second, when the `CompletionStage` is completed in the
original thread pool, as explained above, context is propagated
from the timeout watcher thread. This isn't particularly efficient,
but I don't see a better way currently.

This commit also makes extra sure that a `CompletionStage` is only
completed once, in case of a timeout. It can either be from the
timeout watcher thread, of from the execution thread, but it must
not be both. First `CompletionStage` completion determines its
output, but it's possible that a second completion runs some of
the dependent stages of the `CompletionStage`, perhaps even
concurrently with the dependent stages from the first completion.