### PR TITLE
log SmallRye Fault Tolerance version during startup

### DIFF
--- a/implementation/fault-tolerance/pom.xml
+++ b/implementation/fault-tolerance/pom.xml
@@ -27,54 +27,15 @@
 
   <name>SmallRye Fault Tolerance: CDI Implementation</name>
 
-  <properties>
-    <java9.sourceDirectory>${project.basedir}/src/main/java9</java9.sourceDirectory>
-    <java9.build.outputDirectory>${project.build.directory}/classes-java9</java9.build.outputDirectory>
-  </properties>
-
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>compile-java9</id>
-            <phase>compile</phase>
-            <configuration>
-              <tasks>
-                <property name="compile_classpath" refid="maven.compile.classpath" />
-                <mkdir dir="${java9.build.outputDirectory}" />
-                <javac fork="true" executable="${env.JAVA_HOME}/bin/javac" srcdir="${java9.sourceDirectory}" destdir="${java9.build.outputDirectory}" classpath="${compile_classpath}" includeantruntime="false" />
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-resources</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}/META-INF/versions/9</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${java9.build.outputDirectory}</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -160,11 +121,6 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>META-INF/versions/9/io/smallrye/faulttolerance/DefaultMethodFallbackProvider.class</exclude>
-              </excludes>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/implementation/fault-tolerance/src/main/resources/smallrye-fault-tolerance.properties
+++ b/implementation/fault-tolerance/src/main/resources/smallrye-fault-tolerance.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -17,8 +17,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>smallrye-fault-tolerance-parent</artifactId>
         <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-fault-tolerance-parent</artifactId>
         <version>4.3.1-SNAPSHOT</version>
     </parent>
 


### PR DESCRIPTION
This commit also removes the old Java 9 compilation hack.
The SmallRye Parent POM includes a much better solution.