### PR TITLE
force creating thread pools with SmallRye Context Propagation

### DIFF
--- a/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagationExecutorFactory.java
+++ b/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagationExecutorFactory.java
@@ -4,7 +4,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 
 import io.smallrye.context.SmallRyeManagedExecutor;
@@ -17,13 +16,12 @@ public class ContextPropagationExecutorFactory implements ExecutorFactory {
 
     @Override
     public ExecutorService createCoreExecutor(int size) {
-        return ManagedExecutor.builder().maxAsync(size).build();
+        return SmallRyeManagedExecutor.builder().withExecutorService(null).maxAsync(size).build();
     }
 
     @Override
     public ExecutorService createExecutor(int coreSize, int size) {
-        SmallRyeManagedExecutor.Builder builder = (SmallRyeManagedExecutor.Builder) ManagedExecutor.builder();
-        return builder.maxAsync(size).build();
+        return SmallRyeManagedExecutor.builder().withExecutorService(null).maxAsync(size).build();
     }
 
     @Override


### PR DESCRIPTION
Latest version of SmallRye Context Propagation no longer creates
a new thread pool for `ManagedExecutor.builder().build()` when
a default thread pool is set (which it is in Quarkus, for example).

Currently, SmallRye Fault Tolerance requires new thread pools that
it can control, so this commit uses the SmallRye Context Propagation
specific API to force thread pool creation.

This unfortunately means that SmallRye Fault Tolerance is tied to
SmallRye Context Propagation. It was before, too, but that was
an accident and could be easily removed. It is an intention now.