### PR TITLE
force creating thread pools with SmallRye Context Propagation

### DIFF
--- a/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagationExecutorFactory.java
+++ b/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagationExecutorFactory.java
@@ -17,13 +17,12 @@ public class ContextPropagationExecutorFactory implements ExecutorFactory {
 
     @Override
     public ExecutorService createCoreExecutor(int size) {
-        return ManagedExecutor.builder().maxAsync(size).build();
+        return SmallRyeManagedExecutor.builder().withNewExecutorService().maxAsync(size).build();
     }
 
     @Override
     public ExecutorService createExecutor(int coreSize, int size) {
-        SmallRyeManagedExecutor.Builder builder = (SmallRyeManagedExecutor.Builder) ManagedExecutor.builder();
-        return builder.maxAsync(size).build();
+        return SmallRyeManagedExecutor.builder().withNewExecutorService().maxAsync(size).build();
     }
 
     @Override


### PR DESCRIPTION
Starting with version 1.0.16, SmallRye Context Propagation no longer
creates a new thread pool for `ManagedExecutor.builder().build()`
when a default thread pool is set (which it is e.g. in Quarkus).

Currently, SmallRye Fault Tolerance requires new thread pools that
it can control, so this commit uses the SmallRye Context Propagation
specific API to force thread pool creation.

This unfortunately means that SmallRye Fault Tolerance is tied to
SmallRye Context Propagation. It was before, too, but that was
an accident and could be easily removed. It is an intention now.

This will become obsolete in a future version, which is rewritten
to only ever use a single thread pool, provided by the integrator.
In other words, this is a temporary workaround.