### PR TITLE
move ServiceLoader calls out of common code path

### DIFF
--- a/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagationRequestContextControllerProvider.java
+++ b/implementation/context-propagation/src/main/java/io/smallrye/faulttolerance/propagation/ContextPropagationRequestContextControllerProvider.java
@@ -6,7 +6,7 @@ import javax.enterprise.context.control.RequestContextController;
 import io.smallrye.faulttolerance.internal.RequestContextControllerProvider;
 
 public class ContextPropagationRequestContextControllerProvider implements RequestContextControllerProvider {
-    private static final RequestContextController DUMMY = new RequestContextController() {
+    private final RequestContextController dummy = new RequestContextController() {
         @Override
         public boolean activate() {
             return false;
@@ -19,6 +19,6 @@ public class ContextPropagationRequestContextControllerProvider implements Reque
 
     @Override
     public RequestContextController get() {
-        return DUMMY;
+        return dummy;
     }
 }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/Timer.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/Timer.java
@@ -24,8 +24,6 @@ public final class Timer {
 
     private static final AtomicInteger COUNTER = new AtomicInteger(0);
 
-    private static final TimerRunnableWrapper RUNNABLE_WRAPPER = TimerRunnableWrapper.load();
-
     private static final Comparator<TimerTask> TIMER_TASK_COMPARATOR = (o1, o2) -> {
         if (o1 == o2) {
             // two different instances are never equal
@@ -36,6 +34,8 @@ public final class Timer {
         // with `equals` (see also above)
         return o1.startTime <= o2.startTime ? -1 : 1;
     };
+
+    private final TimerRunnableWrapper runnableWrapper = TimerRunnableWrapper.load();
 
     private final SortedSet<TimerTask> tasks;
 
@@ -94,7 +94,7 @@ public final class Timer {
 
     public TimerTask schedule(long delayInMillis, Runnable runnable) {
         long startTime = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayInMillis);
-        TimerTask task = new TimerTask(startTime, RUNNABLE_WRAPPER.wrap(runnable), tasks::remove);
+        TimerTask task = new TimerTask(startTime, runnableWrapper.wrap(runnable), tasks::remove);
         tasks.add(task);
         LockSupport.unpark(thread);
         return task;

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceExtension.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceExtension.java
@@ -103,6 +103,8 @@ public class FaultToleranceExtension implements Extension {
         bbd.addAnnotatedType(bm.createAnnotatedType(StrategyCache.class), StrategyCache.class.getName());
         bbd.addAnnotatedType(bm.createAnnotatedType(CircuitBreakerMaintenanceImpl.class),
                 CircuitBreakerMaintenanceImpl.class.getName());
+        bbd.addAnnotatedType(bm.createAnnotatedType(RequestContextIntegration.class),
+                RequestContextIntegration.class.getName());
     }
 
     void changeInterceptorPriority(@Observes ProcessAnnotatedType<FaultToleranceInterceptor> event) {

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceInterceptor.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceInterceptor.java
@@ -80,7 +80,6 @@ import io.smallrye.faulttolerance.core.timeout.TimerTimeoutWatcher;
 import io.smallrye.faulttolerance.core.timer.Timer;
 import io.smallrye.faulttolerance.core.util.SetOfThrowables;
 import io.smallrye.faulttolerance.internal.InterceptionPoint;
-import io.smallrye.faulttolerance.internal.RequestContextControllerProvider;
 import io.smallrye.faulttolerance.internal.RequestScopeActivator;
 import io.smallrye.faulttolerance.internal.StrategyCache;
 import io.smallrye.faulttolerance.metrics.MetricsProvider;
@@ -123,6 +122,7 @@ public class FaultToleranceInterceptor {
             FallbackHandlerProvider fallbackHandlerProvider,
             MetricsProvider metricsProvider,
             ExecutorHolder executorHolder,
+            RequestContextIntegration requestContextIntegration,
             CircuitBreakerMaintenanceImpl cbMaintenance) {
         this.interceptedBean = interceptedBean;
         this.operationProvider = operationProvider;
@@ -131,7 +131,7 @@ public class FaultToleranceInterceptor {
         this.metricsProvider = metricsProvider;
         asyncExecutor = executorHolder.getAsyncExecutor();
         timer = executorHolder.getTimer();
-        requestContextController = RequestContextControllerProvider.load().get();
+        requestContextController = requestContextIntegration.get();
         this.cbMaintenance = cbMaintenance;
     }
 

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/RequestContextIntegration.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/RequestContextIntegration.java
@@ -1,0 +1,15 @@
+package io.smallrye.faulttolerance;
+
+import javax.enterprise.context.control.RequestContextController;
+import javax.inject.Singleton;
+
+import io.smallrye.faulttolerance.internal.RequestContextControllerProvider;
+
+@Singleton
+public class RequestContextIntegration {
+    private final RequestContextControllerProvider provider = RequestContextControllerProvider.load();
+
+    public RequestContextController get() {
+        return provider.get();
+    }
+}


### PR DESCRIPTION
In addition, some fields are no longer `static` to prevent possible
issues in modular classloading environment.