### PR TITLE
remove incorrect CompletableFuture.cancel from CompletionStageTimeout

### DIFF
--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timeout/CompletionStageTimeout.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timeout/CompletionStageTimeout.java
@@ -5,26 +5,14 @@ import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
 import io.smallrye.faulttolerance.core.InvocationContext;
 
 public class CompletionStageTimeout<V> extends Timeout<CompletionStage<V>> {
-    // TODO only for unit tests, they need to be rewritten to always run CompletionStage* strategies asynchronously
-    private final boolean interruptCurrentThread;
-
     public CompletionStageTimeout(FaultToleranceStrategy<CompletionStage<V>> delegate, String description, long timeoutInMillis,
             TimeoutWatcher watcher) {
         super(delegate, description, timeoutInMillis, watcher);
-        this.interruptCurrentThread = false;
-    }
-
-    // only for tests
-    CompletionStageTimeout(FaultToleranceStrategy<CompletionStage<V>> delegate, String description, long timeoutInMillis,
-            TimeoutWatcher watcher, boolean interruptCurrentThread) {
-        super(delegate, description, timeoutInMillis, watcher);
-        this.interruptCurrentThread = interruptCurrentThread;
     }
 
     @Override
@@ -34,31 +22,19 @@ public class CompletionStageTimeout<V> extends Timeout<CompletionStage<V>> {
         ctx.fireEvent(TimeoutEvents.Started.INSTANCE);
 
         AtomicBoolean completedWithTimeout = new AtomicBoolean(false);
-        AtomicReference<CompletionStage<V>> runningTaskRef = new AtomicReference<>();
-        Thread threadToInterrupt = interruptCurrentThread ? Thread.currentThread() : null;
-        TimeoutExecution timeoutExecution = new TimeoutExecution(threadToInterrupt, timeoutInMillis, () -> {
+        Runnable onTimeout = () -> {
             if (completedWithTimeout.compareAndSet(false, true)) {
                 ctx.fireEvent(TimeoutEvents.Finished.TIMED_OUT);
-
-                CompletionStage<V> runningTask = runningTaskRef.get();
-                if (runningTask != null) {
-                    // we pass `null` to the `TimeoutExecution` because we can't know in advance which thread to interrupt
-                    // here, we compensate for that by interruptibly-cancelling the running task, if there's one
-                    // TODO the comment above is wrong, see https://github.com/smallrye/smallrye-fault-tolerance/issues/213
-                    runningTask.toCompletableFuture().cancel(true);
-                }
-
                 result.completeExceptionally(timeoutException(description));
             }
-        });
+        };
+
+        TimeoutExecution timeoutExecution = new TimeoutExecution(null, timeoutInMillis, onTimeout);
         TimeoutWatch watch = watcher.schedule(timeoutExecution);
 
         CompletionStage<V> originalResult;
         try {
             originalResult = delegate.apply(ctx);
-            if (!interruptCurrentThread) {
-                runningTaskRef.set(originalResult);
-            }
         } catch (Exception e) {
             originalResult = failedStage(e);
         }
@@ -71,10 +47,7 @@ public class CompletionStageTimeout<V> extends Timeout<CompletionStage<V>> {
             timeoutExecution.finish(watch::cancel);
 
             if (timeoutExecution.hasTimedOut()) {
-                if (completedWithTimeout.compareAndSet(false, true)) {
-                    ctx.fireEvent(TimeoutEvents.Finished.TIMED_OUT);
-                    result.completeExceptionally(timeoutException(description));
-                }
+                onTimeout.run();
             } else if (exception != null) {
                 ctx.fireEvent(TimeoutEvents.Finished.NORMALLY);
                 result.completeExceptionally(exception);

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/fallback/CompletionStageFallbackTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/fallback/CompletionStageFallbackTest.java
@@ -1,116 +1,144 @@
 package io.smallrye.faulttolerance.core.fallback;
 
+import static io.smallrye.faulttolerance.core.Invocation.invocation;
 import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
 import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
-import static io.smallrye.faulttolerance.core.util.TestThread.runOnTestThread;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
+import io.smallrye.faulttolerance.core.InvocationContext;
+import io.smallrye.faulttolerance.core.async.CompletionStageExecution;
 import io.smallrye.faulttolerance.core.util.SetOfThrowables;
 import io.smallrye.faulttolerance.core.util.TestException;
-import io.smallrye.faulttolerance.core.util.TestThread;
+import io.smallrye.faulttolerance.core.util.TestExecutor;
 import io.smallrye.faulttolerance.core.util.barrier.Barrier;
 
 public class CompletionStageFallbackTest {
+    private TestExecutor executor;
+
+    @BeforeEach
+    public void setUp() {
+        executor = new TestExecutor();
+    }
+
     @Test
     public void immediatelyReturning_valueThenValue() throws Exception {
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
                 .immediatelyReturning(() -> completedStage("foobar"));
-        TestThread<CompletionStage<String>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> completedStage("fallback"),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThat(result.await().toCompletableFuture().get()).isEqualTo("foobar");
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThat(result.toCompletableFuture().get()).isEqualTo("foobar");
     }
 
     @Test
     public void immediatelyReturning_valueThenDirectException() throws Exception {
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
                 .immediatelyReturning(() -> completedStage("foobar"));
-        TestThread<CompletionStage<String>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> TestException.doThrow(),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThat(result.await().toCompletableFuture().get()).isEqualTo("foobar");
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThat(result.toCompletableFuture().get()).isEqualTo("foobar");
     }
 
     @Test
     public void immediatelyReturning_valueThenCompletionStageException() throws Exception {
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
                 .immediatelyReturning(() -> completedStage("foobar"));
-        TestThread<CompletionStage<String>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> failedStage(new TestException()),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThat(result.await().toCompletableFuture().get()).isEqualTo("foobar");
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThat(result.toCompletableFuture().get()).isEqualTo("foobar");
     }
 
     @Test
     public void immediatelyReturning_directExceptionThenValue() throws Exception {
         TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
-        TestThread<CompletionStage<String>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> completedStage("fallback"),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThat(result.await().toCompletableFuture().get()).isEqualTo("fallback");
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThat(result.toCompletableFuture().get()).isEqualTo("fallback");
     }
 
     @Test
     public void immediatelyReturning_completionStageExceptionThenValue() throws Exception {
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
                 .immediatelyReturning(() -> failedStage(new TestException()));
-        TestThread<CompletionStage<String>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> completedStage("fallback"),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThat(result.await().toCompletableFuture().get()).isEqualTo("fallback");
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThat(result.toCompletableFuture().get()).isEqualTo("fallback");
     }
 
     @Test
-    public void immediatelyReturning_directExceptionThenDirectException() throws Exception {
+    public void immediatelyReturning_directExceptionThenDirectException() {
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
-        TestThread<CompletionStage<Void>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> {
                     throw new RuntimeException();
-                }, SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThatThrownBy(result.await().toCompletableFuture()::get)
+                }, SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<Void> result = fallback.apply(new InvocationContext<>(null));
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void immediatelyReturning_directExceptionThenCompletionStageException() throws Exception {
+    public void immediatelyReturning_directExceptionThenCompletionStageException() {
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
-        TestThread<CompletionStage<Void>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> failedStage(new RuntimeException()),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThatThrownBy(result.await().toCompletableFuture()::get)
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<Void> result = fallback.apply(new InvocationContext<>(null));
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void immediatelyReturning_completionStageExceptionThenDirectException() throws Exception {
+    public void immediatelyReturning_completionStageExceptionThenDirectException() {
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation
                 .immediatelyReturning(() -> failedStage(new TestException()));
-        TestThread<CompletionStage<Void>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> {
                     throw new RuntimeException();
-                }, SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThatThrownBy(result.await().toCompletableFuture()::get)
+                }, SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<Void> result = fallback.apply(new InvocationContext<>(null));
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void immediatelyReturning_completionStageExceptionThenCompletionStageException() throws Exception {
+    public void immediatelyReturning_completionStageExceptionThenCompletionStageException() {
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation
                 .immediatelyReturning(() -> failedStage(new TestException()));
-        TestThread<CompletionStage<Void>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> failedStage(new RuntimeException()),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThatThrownBy(result.await().toCompletableFuture()::get)
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<Void> result = fallback.apply(new InvocationContext<>(null));
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(RuntimeException.class);
     }
@@ -124,53 +152,59 @@ public class CompletionStageFallbackTest {
         Barrier endBarrier = Barrier.interruptible();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation.waitingOnBarrier(startBarrier, endBarrier,
                 () -> completedStage("foobar"));
-        TestThread<CompletionStage<String>> executingThread = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> completedStage("fallback"),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         startBarrier.await();
-        executingThread.interrupt();
-        assertThatThrownBy(executingThread.await().toCompletableFuture()::get)
+        executor.interruptExecutingThread();
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(InterruptedException.class);
     }
 
     @Test
     public void waitingOnBarrier_interruptedInFallback_directException() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
         Barrier startBarrier = Barrier.interruptible();
         Barrier endBarrier = Barrier.interruptible();
-        FallbackFunction<CompletionStage<String>> fallback = ctx -> {
+        FallbackFunction<CompletionStage<String>> fallbackFunction = ctx -> {
             startBarrier.open();
             endBarrier.await();
             return completedStage("fallback");
         };
-        TestThread<CompletionStage<String>> executingThread = runOnTestThread(new CompletionStageFallback<>(invocation,
-                "test invocation", fallback,
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
+                "test invocation", fallbackFunction,
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         startBarrier.await();
-        executingThread.interrupt();
-        assertThatThrownBy(executingThread.await().toCompletableFuture()::get)
+        executor.interruptExecutingThread();
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(InterruptedException.class);
     }
 
     @Test
     public void waitingOnBarrier_interruptedInFallback_completionStageException() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .immediatelyReturning(() -> failedStage(new TestException()));
         Barrier startBarrier = Barrier.interruptible();
         Barrier endBarrier = Barrier.interruptible();
-        FallbackFunction<CompletionStage<String>> fallback = ctx -> {
+        FallbackFunction<CompletionStage<String>> fallbackFunction = ctx -> {
             startBarrier.open();
             endBarrier.await();
             return completedStage("fallback");
         };
-        TestThread<CompletionStage<String>> executingThread = runOnTestThread(new CompletionStageFallback<>(invocation,
-                "test invocation", fallback,
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation
+                .immediatelyReturning(() -> failedStage(new TestException()));
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
+                "test invocation", fallbackFunction,
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         startBarrier.await();
-        executingThread.interrupt();
-        assertThatThrownBy(executingThread.await().toCompletableFuture()::get)
+        executor.interruptExecutingThread();
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(InterruptedException.class);
     }
@@ -181,79 +215,91 @@ public class CompletionStageFallbackTest {
             Thread.currentThread().interrupt();
             return completedStage("foobar");
         };
-        TestThread<CompletionStage<String>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> completedStage("fallback"),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThat(result.await().toCompletableFuture().get()).isEqualTo("foobar");
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThat(result.toCompletableFuture().get()).isEqualTo("foobar");
     }
 
     @Test
-    public void selfInterruptedInInvocation_directException() throws Exception {
+    public void selfInterruptedInInvocation_directException() {
         FaultToleranceStrategy<CompletionStage<String>> invocation = (ignored) -> {
             Thread.currentThread().interrupt();
             throw new RuntimeException();
         };
-        TestThread<CompletionStage<String>> executingThread = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> completedStage("fallback"),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThatThrownBy(executingThread.await().toCompletableFuture()::get)
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(InterruptedException.class);
     }
 
     @Test
-    public void selfInterruptedInInvocation_completionStageException() throws Exception {
+    public void selfInterruptedInInvocation_completionStageException() {
         FaultToleranceStrategy<CompletionStage<String>> invocation = (ignored) -> {
             Thread.currentThread().interrupt();
             return failedStage(new RuntimeException());
         };
-        TestThread<CompletionStage<String>> executingThread = runOnTestThread(new CompletionStageFallback<>(invocation,
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> completedStage("fallback"),
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThatThrownBy(executingThread.await().toCompletableFuture()::get)
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(InterruptedException.class);
     }
 
     @Test
     public void selfInterruptedInFallback_value() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
-        FallbackFunction<CompletionStage<String>> fallback = ctx -> {
+        FallbackFunction<CompletionStage<String>> fallbackFunction = ctx -> {
             Thread.currentThread().interrupt();
             return completedStage("fallback");
         };
-        TestThread<CompletionStage<String>> result = runOnTestThread(new CompletionStageFallback<>(invocation,
-                "test invocation", fallback,
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThat(result.await().toCompletableFuture().get()).isEqualTo("fallback");
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
+                "test invocation", fallbackFunction,
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThat(result.toCompletableFuture().get()).isEqualTo("fallback");
     }
 
     @Test
-    public void selfInterruptedInFallback_directException() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
-        FallbackFunction<CompletionStage<String>> fallback = ctx -> {
+    public void selfInterruptedInFallback_directException() {
+        FallbackFunction<CompletionStage<String>> fallbackFunction = ctx -> {
             Thread.currentThread().interrupt();
             throw new RuntimeException();
         };
-        TestThread<CompletionStage<String>> executingThread = runOnTestThread(new CompletionStageFallback<>(invocation,
-                "test invocation", fallback,
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThatThrownBy(executingThread.await().toCompletableFuture()::get)
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
+                "test invocation", fallbackFunction,
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void selfInterruptedInFallback_completionStageException() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
-        FallbackFunction<CompletionStage<String>> fallback = ctx -> {
+    public void selfInterruptedInFallback_completionStageException() {
+        FallbackFunction<CompletionStage<String>> fallbackFunction = ctx -> {
             Thread.currentThread().interrupt();
             return failedStage(new RuntimeException());
         };
-        TestThread<CompletionStage<String>> executingThread = runOnTestThread(new CompletionStageFallback<>(invocation,
-                "test invocation", fallback,
-                SetOfThrowables.ALL, SetOfThrowables.EMPTY));
-        assertThatThrownBy(executingThread.await().toCompletableFuture()::get)
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.immediatelyReturning(TestException::doThrow);
+        CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
+        CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
+                "test invocation", fallbackFunction,
+                SetOfThrowables.ALL, SetOfThrowables.EMPTY);
+        CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
+        assertThatThrownBy(result.toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(RuntimeException.class);
     }


### PR DESCRIPTION
The `CompletionStageTimeout` strategy used `CompletableFuture.cancel`
in an attempt to interrupt the executing thread. That is wrong,
as `CompletionStage` (and hence also `CompletableFuture`) doesn't
support cancellation. The `cancel` method only completes the future
with an exception, but doesn't (and can't) interrupt anything.
The code is now removed, and unit tests are adjusted to always
run `CompletionStage` strategies on an extra thread. (And not only
`CompletionStageTimeout` tests, but all `CompletionStage` tests.)

Resolves #213.