### PR TITLE
fix circuit breaker exception handling in half-open

### DIFF
--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/Timer.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/Timer.java
@@ -1,5 +1,7 @@
 package io.smallrye.faulttolerance.core.timer;
 
+import static io.smallrye.faulttolerance.core.timer.TimerLogger.LOG;
+
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.SortedSet;
@@ -9,8 +11,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
-
-import static io.smallrye.faulttolerance.core.timer.TimerLogger.LOG;
 
 /**
  * Allows scheduling tasks ({@code Runnable}s) to be executed on an {@code Executor} after some delay.

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/TimerTask.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/TimerTask.java
@@ -1,9 +1,9 @@
 package io.smallrye.faulttolerance.core.timer;
 
+import static io.smallrye.faulttolerance.core.timer.TimerLogger.LOG;
+
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-
-import static io.smallrye.faulttolerance.core.timer.TimerLogger.LOG;
 
 public final class TimerTask {
     static final int STATE_NEW = 0; // was scheduled, but isn't running yet

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/failon/halfopen/AsyncHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/failon/halfopen/AsyncHelloService.java
@@ -1,0 +1,35 @@
+package io.smallrye.faulttolerance.async.compstage.circuit.breaker.failon.halfopen;
+
+import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
+import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+@ApplicationScoped
+public class AsyncHelloService {
+    static final int ROLLING_WINDOW = 4;
+    static final int DELAY = 200;
+
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    @Asynchronous
+    @CircuitBreaker(requestVolumeThreshold = ROLLING_WINDOW, failOn = IllegalArgumentException.class, delay = DELAY)
+    public CompletionStage<String> hello(Exception e) {
+        counter.incrementAndGet();
+
+        if (e == null) {
+            return completedStage("Hello, world!");
+        }
+        return failedStage(e);
+    }
+
+    AtomicInteger getCounter() {
+        return counter;
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/failon/halfopen/CompletionStageCircuitBreakerFailOnHalfOpenTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/failon/halfopen/CompletionStageCircuitBreakerFailOnHalfOpenTest.java
@@ -1,0 +1,47 @@
+package io.smallrye.faulttolerance.async.compstage.circuit.breaker.failon.halfopen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class CompletionStageCircuitBreakerFailOnHalfOpenTest {
+    @Test
+    public void testCircuitBreakerOpens(AsyncHelloService service) throws InterruptedException {
+        // closed
+        for (int i = 1; i <= AsyncHelloService.ROLLING_WINDOW; i++) {
+            assertThatThrownBy(() -> service.hello(new IllegalArgumentException()).toCompletableFuture().get())
+                    .isExactlyInstanceOf(ExecutionException.class)
+                    .hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+        }
+        assertThat(service.getCounter()).hasValue(AsyncHelloService.ROLLING_WINDOW);
+
+        // open
+        assertThatThrownBy(() -> service.hello(null).toCompletableFuture().get())
+                .isExactlyInstanceOf(ExecutionException.class)
+                .hasCauseExactlyInstanceOf(CircuitBreakerOpenException.class);
+
+        // await until half-open, then move to closed
+        await().atMost(5 * AsyncHelloService.DELAY, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            assertThatThrownBy(() -> service.hello(new IllegalStateException()).toCompletableFuture().get())
+                    .isExactlyInstanceOf(ExecutionException.class)
+                    .hasCauseExactlyInstanceOf(IllegalStateException.class);
+        });
+
+        // closed
+        for (int i = 1; i <= 10; i++) {
+            assertThatThrownBy(() -> service.hello(new IllegalStateException()).toCompletableFuture().get())
+                    .isExactlyInstanceOf(ExecutionException.class)
+                    .hasCauseExactlyInstanceOf(IllegalStateException.class);
+        }
+        assertThat(service.getCounter()).hasValue(AsyncHelloService.ROLLING_WINDOW + 11);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/failon/halfopen/CircuitBreakerFailOnHalfOpenTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/failon/halfopen/CircuitBreakerFailOnHalfOpenTest.java
@@ -1,0 +1,42 @@
+package io.smallrye.faulttolerance.circuitbreaker.failon.halfopen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class CircuitBreakerFailOnHalfOpenTest {
+    @Test
+    public void testCircuitBreakerOpens(HelloService service) throws InterruptedException {
+        // closed
+        for (int i = 1; i <= HelloService.ROLLING_WINDOW; i++) {
+            assertThatThrownBy(() -> service.hello(new IllegalArgumentException()))
+                    .isExactlyInstanceOf(IllegalArgumentException.class);
+        }
+        assertThat(service.getCounter()).hasValue(HelloService.ROLLING_WINDOW);
+
+        // open
+        assertThatThrownBy(() -> service.hello(null))
+                .isExactlyInstanceOf(CircuitBreakerOpenException.class);
+
+        // await until half-open, then move to closed
+        await().atMost(5 * HelloService.DELAY, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            assertThatThrownBy(() -> service.hello(new IllegalStateException()))
+                    .isExactlyInstanceOf(IllegalStateException.class);
+        });
+
+        // closed
+        for (int i = 1; i <= 10; i++) {
+            assertThatThrownBy(() -> service.hello(new IllegalStateException()))
+                    .isExactlyInstanceOf(IllegalStateException.class);
+        }
+        assertThat(service.getCounter()).hasValue(HelloService.ROLLING_WINDOW + 11);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/failon/halfopen/HelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/failon/halfopen/HelloService.java
@@ -1,0 +1,29 @@
+package io.smallrye.faulttolerance.circuitbreaker.failon.halfopen;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+@ApplicationScoped
+public class HelloService {
+    static final int ROLLING_WINDOW = 4;
+    static final int DELAY = 200;
+
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    @CircuitBreaker(requestVolumeThreshold = ROLLING_WINDOW, failOn = IllegalArgumentException.class, delay = DELAY)
+    public String hello(Exception e) throws Exception {
+        counter.incrementAndGet();
+
+        if (e == null) {
+            return "Hello, world!";
+        }
+        throw e;
+    }
+
+    AtomicInteger getCounter() {
+        return counter;
+    }
+}


### PR DESCRIPTION
Previously, when the circuit breaker was half-open, it would always
consider exceptions as failures. This is wrong, the `failOn` and
`skipOn` configuration needs to be considered, just like when closed.

This commit fixes that, adds tests, and also adds some missing
trace logging to `CompletionStageCircuitBreaker`.

Fixes #320