### PR TITLE
improve circuit breaker to reject excess attempts in half-open

### DIFF
--- a/implementation/core/pom.xml
+++ b/implementation/core/pom.xml
@@ -64,6 +64,45 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io/smallrye/faulttolerance/core/util/barrier/*</include>
+                                <include>io/smallrye/faulttolerance/core/util/party/*</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar-no-fork</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io/smallrye/faulttolerance/core/util/barrier/*</include>
+                                <include>io/smallrye/faulttolerance/core/util/party/*</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>jacoco</id>

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/util/party/Party.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/util/party/Party.java
@@ -1,0 +1,21 @@
+package io.smallrye.faulttolerance.core.util.party;
+
+public interface Party {
+    Participant participant();
+
+    Organizer organizer();
+
+    static Party create(int participants) {
+        return new PartyImpl(participants);
+    }
+
+    interface Participant {
+        void attend() throws InterruptedException;
+    }
+
+    interface Organizer {
+        void waitForAll() throws InterruptedException;
+
+        void disband();
+    }
+}

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/util/party/PartyImpl.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/util/party/PartyImpl.java
@@ -1,0 +1,65 @@
+package io.smallrye.faulttolerance.core.util.party;
+
+import java.util.concurrent.CountDownLatch;
+
+final class PartyImpl implements Party {
+    private final Participant participant;
+
+    private final Organizer organizer;
+
+    PartyImpl(int participants) {
+        CountDownLatch arriveLatch = new CountDownLatch(participants);
+        CountDownLatch disbandLatch = new CountDownLatch(1);
+
+        participant = new ParticipantImpl(arriveLatch, disbandLatch);
+        organizer = new OrganizerImpl(arriveLatch, disbandLatch);
+    }
+
+    @Override
+    public Participant participant() {
+        return participant;
+    }
+
+    @Override
+    public Organizer organizer() {
+        return organizer;
+    }
+
+    private static final class ParticipantImpl implements Participant {
+        private final CountDownLatch arriveLatch;
+
+        private final CountDownLatch disbandLatch;
+
+        ParticipantImpl(CountDownLatch arriveLatch, CountDownLatch disbandLatch) {
+            this.arriveLatch = arriveLatch;
+            this.disbandLatch = disbandLatch;
+        }
+
+        @Override
+        public void attend() throws InterruptedException {
+            arriveLatch.countDown();
+            disbandLatch.await();
+        }
+    }
+
+    private static final class OrganizerImpl implements Organizer {
+        private final CountDownLatch arriveLatch;
+
+        private final CountDownLatch disbandLatch;
+
+        OrganizerImpl(CountDownLatch arriveLatch, CountDownLatch disbandLatch) {
+            this.arriveLatch = arriveLatch;
+            this.disbandLatch = disbandLatch;
+        }
+
+        @Override
+        public void waitForAll() throws InterruptedException {
+            arriveLatch.await();
+        }
+
+        @Override
+        public void disband() {
+            disbandLatch.countDown();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,13 @@
 
             <dependency>
                 <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-core</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>smallrye-fault-tolerance</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-fault-tolerance-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.smallrye.config</groupId>

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/failon/halfopen/CompletionStageCircuitBreakerFailOnHalfOpenTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/failon/halfopen/CompletionStageCircuitBreakerFailOnHalfOpenTest.java
@@ -15,9 +15,9 @@ import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
 @FaultToleranceBasicTest
 public class CompletionStageCircuitBreakerFailOnHalfOpenTest {
     @Test
-    public void testCircuitBreakerOpens(AsyncHelloService service) throws InterruptedException {
+    public void halfOpenCircuitBreakerTreatsConfiguredExceptionsAsSuccess(AsyncHelloService service) {
         // closed
-        for (int i = 1; i <= AsyncHelloService.ROLLING_WINDOW; i++) {
+        for (int i = 0; i < AsyncHelloService.ROLLING_WINDOW; i++) {
             assertThatThrownBy(() -> service.hello(new IllegalArgumentException()).toCompletableFuture().get())
                     .isExactlyInstanceOf(ExecutionException.class)
                     .hasCauseExactlyInstanceOf(IllegalArgumentException.class);

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/halfopen/AsyncHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/halfopen/AsyncHelloService.java
@@ -1,0 +1,43 @@
+package io.smallrye.faulttolerance.async.compstage.circuit.breaker.halfopen;
+
+import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
+import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import io.smallrye.faulttolerance.core.util.party.Party;
+
+@ApplicationScoped
+public class AsyncHelloService {
+    static final int ROLLING_WINDOW = 10;
+    static final int DELAY = 200;
+    static final int PROBE_ATTEMPTS = 5;
+
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    @Asynchronous
+    @CircuitBreaker(requestVolumeThreshold = ROLLING_WINDOW, delay = DELAY, successThreshold = PROBE_ATTEMPTS)
+    public CompletionStage<String> hello(boolean fail, Party.Participant participant) throws InterruptedException {
+        counter.incrementAndGet();
+
+        if (fail) {
+            return failedStage(new IllegalArgumentException());
+        }
+
+        if (participant != null) {
+            participant.attend();
+        }
+
+        return completedStage("Hello, world!");
+    }
+
+    AtomicInteger getCounter() {
+        return counter;
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/halfopen/CompletionStageCircuitBreakerHalfOpenTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/halfopen/CompletionStageCircuitBreakerHalfOpenTest.java
@@ -1,0 +1,72 @@
+package io.smallrye.faulttolerance.async.compstage.circuit.breaker.halfopen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.core.util.party.Party;
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class CompletionStageCircuitBreakerHalfOpenTest {
+    @Test
+    public void halfOpenCircuitBreakerRejectsExcessAttempts(AsyncHelloService service)
+            throws ExecutionException, InterruptedException {
+        // closed
+        for (int i = 0; i < AsyncHelloService.ROLLING_WINDOW; i++) {
+            assertThatThrownBy(() -> service.hello(true, null).toCompletableFuture().get())
+                    .isExactlyInstanceOf(ExecutionException.class)
+                    .hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+        }
+        assertThat(service.getCounter()).hasValue(AsyncHelloService.ROLLING_WINDOW);
+
+        // open
+        for (int i = 0; i < 10; i++) {
+            assertThatThrownBy(() -> service.hello(false, null).toCompletableFuture().get())
+                    .isExactlyInstanceOf(ExecutionException.class)
+                    .hasCauseExactlyInstanceOf(CircuitBreakerOpenException.class);
+        }
+
+        // await until half-open
+        await().atMost(5 * AsyncHelloService.DELAY, TimeUnit.MILLISECONDS).ignoreExceptions().untilAsserted(() -> {
+            assertThat(service.hello(false, null).toCompletableFuture().get()).isEqualTo("Hello, world!");
+        });
+
+        // half-open, 1st probe invocation already succeeded
+        Party party = Party.create(AsyncHelloService.PROBE_ATTEMPTS - 1);
+        List<CompletionStage<String>> futures = new ArrayList<>();
+        for (int i = 0; i < AsyncHelloService.PROBE_ATTEMPTS - 1; i++) {
+            CompletionStage<String> future = service.hello(false, party.participant());
+            futures.add(future);
+        }
+
+        party.organizer().waitForAll();
+
+        // still half-open, but all allowed probe attempts are now running
+        for (int i = 0; i < 10; i++) {
+            assertThatThrownBy(() -> service.hello(false, null).toCompletableFuture().get())
+                    .isExactlyInstanceOf(ExecutionException.class)
+                    .hasCauseExactlyInstanceOf(CircuitBreakerOpenException.class);
+        }
+
+        party.organizer().disband();
+
+        for (CompletionStage<String> future : futures) {
+            assertThat(future.toCompletableFuture().get()).isEqualTo("Hello, world!");
+        }
+
+        // closed
+        assertThat(service.hello(false, null).toCompletableFuture().get()).isEqualTo("Hello, world!");
+
+        assertThat(service.getCounter()).hasValue(AsyncHelloService.ROLLING_WINDOW + AsyncHelloService.PROBE_ATTEMPTS + 1);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/failon/halfopen/CircuitBreakerFailOnHalfOpenTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/failon/halfopen/CircuitBreakerFailOnHalfOpenTest.java
@@ -14,9 +14,9 @@ import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
 @FaultToleranceBasicTest
 public class CircuitBreakerFailOnHalfOpenTest {
     @Test
-    public void testCircuitBreakerOpens(HelloService service) throws InterruptedException {
+    public void halfOpenCircuitBreakerTreatsConfiguredExceptionsAsSuccess(HelloService service) {
         // closed
-        for (int i = 1; i <= HelloService.ROLLING_WINDOW; i++) {
+        for (int i = 0; i < HelloService.ROLLING_WINDOW; i++) {
             assertThatThrownBy(() -> service.hello(new IllegalArgumentException()))
                     .isExactlyInstanceOf(IllegalArgumentException.class);
         }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/halfopen/CircuitBreakerHalfOpenTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/halfopen/CircuitBreakerHalfOpenTest.java
@@ -1,0 +1,86 @@
+package io.smallrye.faulttolerance.circuitbreaker.halfopen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.core.util.party.Party;
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class CircuitBreakerHalfOpenTest {
+    private ExecutorService executor;
+
+    @BeforeEach
+    public void setUp() {
+        executor = Executors.newFixedThreadPool(HelloService.PROBE_ATTEMPTS);
+    }
+
+    @AfterEach
+    public void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void halfOpenCircuitBreakerRejectsExcessAttempts(HelloService service)
+            throws ExecutionException, InterruptedException {
+        // closed
+        for (int i = 0; i < HelloService.ROLLING_WINDOW; i++) {
+            assertThatThrownBy(() -> service.hello(true, null))
+                    .isExactlyInstanceOf(IllegalArgumentException.class);
+        }
+        assertThat(service.getCounter()).hasValue(HelloService.ROLLING_WINDOW);
+
+        // open
+        for (int i = 0; i < 10; i++) {
+            assertThatThrownBy(() -> service.hello(false, null))
+                    .isExactlyInstanceOf(CircuitBreakerOpenException.class);
+        }
+
+        // await until half-open
+        await().atMost(5 * HelloService.DELAY, TimeUnit.MILLISECONDS).ignoreExceptions().untilAsserted(() -> {
+            assertThat(service.hello(false, null)).isEqualTo("Hello, world!");
+        });
+
+        // half-open, 1st probe invocation already succeeded
+        Party party = Party.create(HelloService.PROBE_ATTEMPTS - 1);
+        List<Future<String>> futures = new ArrayList<>();
+        for (int i = 0; i < HelloService.PROBE_ATTEMPTS - 1; i++) {
+            Future<String> future = executor.submit(() -> service.hello(false, party.participant()));
+            futures.add(future);
+        }
+
+        party.organizer().waitForAll();
+
+        // still half-open, but all allowed probe attempts are now running
+        for (int i = 0; i < 10; i++) {
+            assertThatThrownBy(() -> service.hello(false, null))
+                    .isExactlyInstanceOf(CircuitBreakerOpenException.class);
+        }
+
+        party.organizer().disband();
+
+        for (Future<String> future : futures) {
+            assertThat(future.get()).isEqualTo("Hello, world!");
+        }
+
+        // closed
+        assertThat(service.hello(false, null)).isEqualTo("Hello, world!");
+
+        assertThat(service.getCounter()).hasValue(HelloService.ROLLING_WINDOW + HelloService.PROBE_ATTEMPTS + 1);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/halfopen/HelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/halfopen/HelloService.java
@@ -1,0 +1,37 @@
+package io.smallrye.faulttolerance.circuitbreaker.halfopen;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import io.smallrye.faulttolerance.core.util.party.Party;
+
+@ApplicationScoped
+public class HelloService {
+    static final int ROLLING_WINDOW = 10;
+    static final int DELAY = 200;
+    static final int PROBE_ATTEMPTS = 5;
+
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    @CircuitBreaker(requestVolumeThreshold = ROLLING_WINDOW, delay = DELAY, successThreshold = PROBE_ATTEMPTS)
+    public String hello(boolean fail, Party.Participant participant) throws InterruptedException {
+        counter.incrementAndGet();
+
+        if (fail) {
+            throw new IllegalArgumentException();
+        }
+
+        if (participant != null) {
+            participant.attend();
+        }
+
+        return "Hello, world!";
+    }
+
+    AtomicInteger getCounter() {
+        return counter;
+    }
+}

--- a/testsuite/basic/src/test/resources/logging.properties
+++ b/testsuite/basic/src/test/resources/logging.properties
@@ -16,5 +16,7 @@
 
 handlers = java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$-5s [%3$s] %5$s%6$s%n
 org.jboss.weld.level = WARNING
 io.smallrye.faulttolerance.level = INFO

--- a/testsuite/integration/src/test/resources/logging.properties
+++ b/testsuite/integration/src/test/resources/logging.properties
@@ -16,5 +16,7 @@
 
 handlers = java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$-5s [%3$s] %5$s%6$s%n
 org.jboss.weld.level = WARNING
 io.smallrye.faulttolerance.level = INFO

--- a/testsuite/tck/src/test/resources/logging.properties
+++ b/testsuite/tck/src/test/resources/logging.properties
@@ -16,5 +16,7 @@
 
 handlers = java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$-5s [%3$s] %5$s%6$s%n
 org.jboss.weld.level = WARNING
 io.smallrye.faulttolerance.level = INFO


### PR DESCRIPTION
Previously, circuit breakers in the half-open state would let
all invocations go through. In case of any failure, it would
move back to open, and in case of a configured number of consecutive
successes, it would move to closed.

This is fine and passes the TCK, but under high load, this can
cause a thundering herd problem on the guarded service.

A better solution, implemented by this commit, is: in half-open,
only allow the first `successThreshold` invocations to go through
(also known as "probe invocations"), and reject the rest. If any
of those probe invocations fail, move back to open; if all of them
succeed, move to closed.

Fixes #319