### PR TITLE
document Vert.x version for the event loop integration

### DIFF
--- a/doc/modules/ROOT/pages/integration/event-loop.adoc
+++ b/doc/modules/ROOT/pages/integration/event-loop.adoc
@@ -19,6 +19,8 @@ If no event loop integration is present, the tasks described above will be offlo
 == Vert.x
 
 {smallrye-fault-tolerance} includes an implementation of the event loop integration API for Vert.x.
+This implementation is compiled and tested against Vert.x version 4.0, but should also work fine with Vert.x 3.x.
+
 This implementation is present in the `io.smallrye:smallrye-fault-tolerance-vertx` artifact.
 Including this artifact is enough to enable the Vert.x integration.
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <version.smallrye-common>1.6.0</version.smallrye-common>
         <version.smallrye-reactive-utils>2.2.0</version.smallrye-reactive-utils>
         <version.opentracing>0.33.0</version.opentracing>
-        <version.vertx>4.0.2</version.vertx>
+        <version.vertx>4.0.3</version.vertx>
 
         <version.junit-pioneer>1.3.8</version.junit-pioneer>
         <version.mutiny>0.14.0</version.mutiny>


### PR DESCRIPTION
Also bump Vert.x to latest micro release.