### PR TITLE
use Google Maven Central mirror as an additional repository in all CI jobs

### DIFF
--- a/.github/maven-ci-settings.xml
+++ b/.github/maven-ci-settings.xml
@@ -1,0 +1,36 @@
+<settings>
+    <profiles>
+        <profile>
+            <id>google-mirror</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>google-maven-central</id>
+                    <name>GCS Maven Central mirror</name>
+                    <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>google-maven-central</id>
+                    <name>GCS Maven Central mirror</name>
+                    <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,12 @@ jobs:
     - name: Build with Maven (Linux, Windows)
       if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest' }}
       shell: bash
-      run: mvn -B formatter:validate verify --file pom.xml
+      run: mvn -s .github/maven-ci-settings.xml -B formatter:validate verify --file pom.xml
 
     - name: Build with Maven (Mac)
       if: ${{ matrix.os == 'macos-latest' }}
       shell: bash
-      run: mvn -B formatter:validate verify --file pom.xml -Dorg.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier=3.0
+      run: mvn -s .github/maven-ci-settings.xml -B formatter:validate verify --file pom.xml -Dorg.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier=3.0
 
     - name: Upload TCK report
       if: ${{ matrix.java == '11' && matrix.os == 'ubuntu-latest' }}
@@ -101,4 +101,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-      run: mvn -B verify --file pom.xml -Pcoverage javadoc:javadoc sonar:sonar -Dsonar.projectKey=smallrye_smallrye-fault-tolerance -Dsonar.login=$SONAR_TOKEN
+      run: mvn -s .github/maven-ci-settings.xml -B verify --file pom.xml -Pcoverage javadoc:javadoc sonar:sonar -Dsonar.projectKey=smallrye_smallrye-fault-tolerance -Dsonar.login=$SONAR_TOKEN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,10 @@ jobs:
           sed -i -e 's|^version: main|version: ${{steps.metadata.outputs.current-version}}|' doc/antora.yml
           sed -i -e 's|smallrye-fault-tolerance-version: .*|smallrye-fault-tolerance-version: '"'"'${{steps.metadata.outputs.current-version}}'"'"'|' doc/antora.yml
           git commit -a -m 'Update antora.yml before release'
-          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -s maven-settings.xml
+          mvn -s .github/maven-ci-settings.xml -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -s maven-settings.xml
           git checkout ${{github.base_ref}}
           git rebase release
-          mvn -B release:perform -Prelease -s maven-settings.xml
+          mvn -s .github/maven-ci-settings.xml -B release:perform -Prelease -s maven-settings.xml
           sed -i -e 's|^version: ${{steps.metadata.outputs.current-version}}|version: main|' doc/antora.yml
           git commit -a -m 'Update antora.yml after release'
           git push


### PR DESCRIPTION
This is to improve CI stability. Maven Central often has short outages
that cause CI failures. Those are usually fixed simply by rerunning
the jobs.