### PR TITLE
Remove non-existent dependency from dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
-  - dependency-name: com.netflix.hystrix:hystrix-core
-    versions:
-    - "> 1.5.12"
   - dependency-name: org.jboss.weld:weld-junit5
     versions:
     - ">= 3.a, < 4"


### PR DESCRIPTION
This configuration got carried over when dependabot suggested migration from dependabot-preview but it didn't account that this dependency has been removed completely.