### PR TITLE
use smallrye-build-parent instead of smallrye-parent

### DIFF
--- a/implementation/fault-tolerance/pom.xml
+++ b/implementation/fault-tolerance/pom.xml
@@ -54,10 +54,6 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/implementation/vertx/pom.xml
+++ b/implementation/vertx/pom.xml
@@ -33,10 +33,6 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-fault-tolerance-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-parent</artifactId>
+        <artifactId>smallrye-build-parent</artifactId>
         <version>29</version>
     </parent>
 
@@ -31,9 +31,12 @@
     <url>http://smallrye.io</url>
 
     <properties>
-        <version.jakarta.enterprise.cdi.api>2.0.2</version.jakarta.enterprise.cdi.api>
-        <version.jakarta.interceptor-api>1.2.5</version.jakarta.interceptor-api>
+        <version.jakarta-annotations>1.3.5</version.jakarta-annotations>
+        <version.jakarta-cdi>2.0.2</version.jakarta-cdi>
+        <version.jakarta-interceptors>1.2.5</version.jakarta-interceptors>
         <version.javapoet>1.13.0</version.javapoet>
+        <version.jboss-logging>3.4.2.Final</version.jboss-logging>
+        <version.jboss-logging-tools>2.2.1.Final</version.jboss-logging-tools>
         <version.microprofile-fault-tolerance>3.0</version.microprofile-fault-tolerance>
         <version.microprofile-config-api>2.0</version.microprofile-config-api>
         <version.microprofile-metrics-api>3.0</version.microprofile-metrics-api>
@@ -49,9 +52,15 @@
         <version.opentracing>0.33.0</version.opentracing>
         <version.vertx>4.1.1</version.vertx>
 
+        <version.arquillian>1.6.0.Final</version.arquillian>
+        <version.arquillian-weld>2.1.0.Final</version.arquillian-weld>
+        <version.assertj>3.20.2</version.assertj>
+        <version.awaitility>4.1.0</version.awaitility>
+        <version.junit-jupiter>5.7.2</version.junit-jupiter>
         <version.junit-pioneer>1.4.2</version.junit-pioneer>
         <version.mutiny>0.19.2</version.mutiny>
         <version.rxjava3>3.0.13</version.rxjava3>
+        <version.testng>6.14.3</version.testng>
         <version.weld-api>3.1.SP4</version.weld-api>
         <version.weld-core>3.1.7.SP1</version.weld-core>
         <version.weld-junit5>2.0.2.Final</version.weld-junit5>
@@ -80,15 +89,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>jakarta.interceptor</groupId>
-                <artifactId>jakarta.interceptor-api</artifactId>
-                <version>${version.jakarta.interceptor-api}</version>
-                <scope>provided</scope>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${version.jakarta-annotations}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>${version.jakarta.enterprise.cdi.api}</version>
+                <version>${version.jakarta-cdi}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>jakarta.el</groupId>
@@ -100,6 +108,11 @@
                         <artifactId>jakarta.ejb-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>${version.jakarta-interceptors}</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup</groupId>
@@ -137,6 +150,23 @@
                 <artifactId>microprofile-fault-tolerance-tck</artifactId>
                 <version>${version.microprofile-fault-tolerance}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.jboss-logging}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging-annotations</artifactId>
+                <version>${version.jboss-logging-tools}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging-processor</artifactId>
+                <version>${version.jboss-logging-tools}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.common</groupId>
@@ -200,6 +230,31 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.assertj}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${version.awaitility}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${version.arquillian}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-weld-embedded</artifactId>
+                <version>${version.arquillian-weld}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-api</artifactId>
                 <version>${version.weld-api}</version>
@@ -228,9 +283,22 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${version.junit-jupiter}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.junit-pioneer</groupId>
                 <artifactId>junit-pioneer</artifactId>
                 <version>${version.junit-pioneer}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${version.testng}</version>
                 <scope>test</scope>
             </dependency>
 
@@ -240,50 +308,42 @@
                 <artifactId>smallrye-fault-tolerance-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-core</artifactId>
                 <type>test-jar</type>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-autoconfig-processor</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-context-propagation</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-tracing-propagation</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-vertx</artifactId>


### PR DESCRIPTION
The `smallrye-build-parent` POM only includes stuff related to
building (including MR JARs) and releasing. It doesn't manage
any dependencies. This lets us fully manage dependencies ourselves,
resulting in more control and more predictable builds.