### PR TITLE
Replaced Thread.sleep calls with Awaitility in CompletionStageThreadPoolBulkheadTest

### DIFF
--- a/implementation/core/pom.xml
+++ b/implementation/core/pom.xml
@@ -70,6 +70,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Replaced Thread.sleep calls with Awaitility and small clean ups in CompletionStageThreadPoolBulkheadTest