### PR TITLE
Prototype "before retry action" support

### DIFF
--- a/api/src/main/java/io/smallrye/faulttolerance/api/BeforeRetryAnnotation.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/BeforeRetryAnnotation.java
@@ -1,0 +1,12 @@
+package io.smallrye.faulttolerance.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface BeforeRetryAnnotation {
+    String beforeRetryMethod() default "";
+}

--- a/implementation/autoconfig/core/src/main/java/io/smallrye/faulttolerance/autoconfig/FaultToleranceMethod.java
+++ b/implementation/autoconfig/core/src/main/java/io/smallrye/faulttolerance/autoconfig/FaultToleranceMethod.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.faulttolerance.api.BeforeRetryAnnotation;
 import io.smallrye.faulttolerance.api.CircuitBreakerName;
 import io.smallrye.faulttolerance.api.CustomBackoff;
 import io.smallrye.faulttolerance.api.ExponentialBackoff;
@@ -41,6 +42,7 @@ public class FaultToleranceMethod {
     public Bulkhead bulkhead;
     public CircuitBreaker circuitBreaker;
     public Fallback fallback;
+    public BeforeRetryAnnotation beforeRetryAnnotation;
     public Retry retry;
     public Timeout timeout;
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/before/retry/BeforeRetry.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/before/retry/BeforeRetry.java
@@ -1,0 +1,33 @@
+package io.smallrye.faulttolerance.core.before.retry;
+
+import static io.smallrye.faulttolerance.core.before.retry.BeforeRetryLogger.LOG;
+
+import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
+import io.smallrye.faulttolerance.core.InvocationContext;
+
+public class BeforeRetry<V> implements FaultToleranceStrategy<V> {
+
+    private final BeforeRetryFunction<V> beforeRetry;
+
+    private final FaultToleranceStrategy<V> delegate;
+
+    public BeforeRetry(FaultToleranceStrategy<V> delegate, BeforeRetryFunction<V> beforeRetry) {
+        this.delegate = delegate;
+        this.beforeRetry = beforeRetry;
+    }
+
+    @Override
+    public V apply(InvocationContext<V> ctx) throws Exception {
+        LOG.trace("BeforeRetry started");
+        try {
+            return doApply(ctx);
+        } finally {
+            LOG.trace("BeforeRetry finished");
+        }
+    }
+
+    private V doApply(InvocationContext<V> ctx) throws Exception {
+        beforeRetry.call(ctx);
+        return delegate.apply(ctx);
+    }
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/before/retry/BeforeRetryFunction.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/before/retry/BeforeRetryFunction.java
@@ -1,0 +1,8 @@
+package io.smallrye.faulttolerance.core.before.retry;
+
+import io.smallrye.faulttolerance.core.InvocationContext;
+
+@FunctionalInterface
+public interface BeforeRetryFunction<T> {
+    void call(InvocationContext<T> invocationContext) throws Exception;
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/before/retry/BeforeRetryLogger.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/before/retry/BeforeRetryLogger.java
@@ -1,0 +1,10 @@
+package io.smallrye.faulttolerance.core.before.retry;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.MessageLogger;
+
+@MessageLogger(projectCode = "SRFTL", length = 5)
+interface BeforeRetryLogger extends BasicLogger {
+    BeforeRetryLogger LOG = Logger.getMessageLogger(BeforeRetryLogger.class, BeforeRetryLogger.class.getPackage().getName());
+}

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/BeforeRetryConfig.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/BeforeRetryConfig.java
@@ -1,0 +1,13 @@
+package io.smallrye.faulttolerance.config;
+
+import io.smallrye.faulttolerance.api.BeforeRetryAnnotation;
+import io.smallrye.faulttolerance.autoconfig.AutoConfig;
+import io.smallrye.faulttolerance.autoconfig.Config;
+
+@AutoConfig
+public interface BeforeRetryConfig extends BeforeRetryAnnotation, Config {
+
+    @Override
+    default void validate() {
+    }
+}

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceMethods.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceMethods.java
@@ -16,6 +16,7 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.faulttolerance.api.BeforeRetryAnnotation;
 import io.smallrye.faulttolerance.api.CircuitBreakerName;
 import io.smallrye.faulttolerance.api.CustomBackoff;
 import io.smallrye.faulttolerance.api.ExponentialBackoff;
@@ -36,6 +37,7 @@ public class FaultToleranceMethods {
         result.bulkhead = getAnnotation(Bulkhead.class, method, annotationsPresentDirectly);
         result.circuitBreaker = getAnnotation(CircuitBreaker.class, method, annotationsPresentDirectly);
         result.fallback = getAnnotation(Fallback.class, method, annotationsPresentDirectly);
+        result.beforeRetryAnnotation = getAnnotation(BeforeRetryAnnotation.class, method, annotationsPresentDirectly);
         result.retry = getAnnotation(Retry.class, method, annotationsPresentDirectly);
         result.timeout = getAnnotation(Timeout.class, method, annotationsPresentDirectly);
 
@@ -82,6 +84,8 @@ public class FaultToleranceMethods {
         result.bulkhead = getAnnotation(Bulkhead.class, method, beanClass, annotationsPresentDirectly);
         result.circuitBreaker = getAnnotation(CircuitBreaker.class, method, beanClass, annotationsPresentDirectly);
         result.fallback = getAnnotation(Fallback.class, method, beanClass, annotationsPresentDirectly);
+        result.beforeRetryAnnotation = getAnnotation(BeforeRetryAnnotation.class, method, beanClass,
+                annotationsPresentDirectly);
         result.retry = getAnnotation(Retry.class, method, beanClass, annotationsPresentDirectly);
         result.timeout = getAnnotation(Timeout.class, method, beanClass, annotationsPresentDirectly);
 

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceOperation.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceOperation.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
+import io.smallrye.faulttolerance.api.BeforeRetryAnnotation;
 import io.smallrye.faulttolerance.api.CircuitBreakerName;
 import io.smallrye.faulttolerance.api.CustomBackoff;
 import io.smallrye.faulttolerance.api.ExponentialBackoff;
@@ -53,6 +54,7 @@ public class FaultToleranceOperation {
                 CircuitBreakerNameConfigImpl.create(method),
                 FallbackConfigImpl.create(method),
                 RetryConfigImpl.create(method),
+                BeforeRetryConfigImpl.create(method),
                 TimeoutConfigImpl.create(method),
                 ExponentialBackoffConfigImpl.create(method),
                 FibonacciBackoffConfigImpl.create(method),
@@ -79,6 +81,8 @@ public class FaultToleranceOperation {
 
     private final RetryConfig retry;
 
+    private final BeforeRetryConfig beforeRetry;
+
     private final TimeoutConfig timeout;
 
     private final ExponentialBackoffConfig exponentialBackoff;
@@ -97,6 +101,7 @@ public class FaultToleranceOperation {
             CircuitBreakerNameConfig circuitBreakerName,
             FallbackConfig fallback,
             RetryConfig retry,
+            BeforeRetryConfig beforeRetry,
             TimeoutConfig timeout,
             ExponentialBackoffConfig exponentialBackoff,
             FibonacciBackoffConfig fibonacciBackoff,
@@ -113,6 +118,7 @@ public class FaultToleranceOperation {
         this.circuitBreakerName = circuitBreakerName;
         this.fallback = fallback;
         this.retry = retry;
+        this.beforeRetry = beforeRetry;
         this.timeout = timeout;
 
         this.exponentialBackoff = exponentialBackoff;
@@ -193,6 +199,14 @@ public class FaultToleranceOperation {
 
     public Fallback getFallback() {
         return fallback;
+    }
+
+    public boolean hasBeforeRetry() {
+        return beforeRetry != null;
+    }
+
+    public BeforeRetryAnnotation getBeforeRetry() {
+        return beforeRetry;
     }
 
     public boolean hasRetry() {

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/before/retry/BeforeRetryTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/before/retry/BeforeRetryTest.java
@@ -1,0 +1,29 @@
+package io.smallrye.faulttolerance.before.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class BeforeRetryTest {
+
+    @Inject
+    private BeforeRetryTestBean beforeRetryTestBean;
+
+    @AfterEach
+    public void cleanUp() {
+        beforeRetryTestBean.reset();
+    }
+
+    @Test
+    public void call() {
+        String value = beforeRetryTestBean.call();
+        assertThat(value).isEqualTo("call 2");
+        assertThat(beforeRetryTestBean.getBeforeRetryRuns()).isEqualTo(2);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/before/retry/BeforeRetryTestBean.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/before/retry/BeforeRetryTestBean.java
@@ -1,0 +1,39 @@
+package io.smallrye.faulttolerance.before.retry;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.Dependent;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.faulttolerance.api.BeforeRetryAnnotation;
+
+@Dependent
+public class BeforeRetryTestBean {
+
+    private final AtomicInteger attempt = new AtomicInteger();
+
+    private final AtomicInteger beforeRetryRuns = new AtomicInteger();
+
+    @Retry(maxRetries = 2)
+    @BeforeRetryAnnotation(beforeRetryMethod = "beforeRetry")
+    public String call() {
+        if (attempt.getAndIncrement() < 1) {
+            throw new IllegalStateException();
+        }
+        return "call " + attempt.get();
+    }
+
+    public void beforeRetry() {
+        beforeRetryRuns.incrementAndGet();
+    }
+
+    public void reset() {
+        attempt.set(0);
+        beforeRetryRuns.set(0);
+    }
+
+    int getBeforeRetryRuns() {
+        return beforeRetryRuns.get();
+    }
+}


### PR DESCRIPTION
PR to solve https://github.com/smallrye/smallrye-fault-tolerance/issues/259.

Considerations:
* This is just an initial implementation. I decided to create this PR to get feedback and discover if it fits with the expectation.
* I implemented the minimum possible to get the feedback fast.
* The implementation is based on Fallback.
* I created io.smallrye.faulttolerance.api.BeforeRetryAnnotation. I don't know if this feature will be specific to SmallRye of if it's intended to be added to MicroProfile. I provisionally put the suffix 'Annotation' in its name to not confuse with the implementation class for now.
* I only implemented the attribute `beforeRetryMethod`. It should be used like the following:

````java
    @Retry(maxRetries = 2)
    @BeforeRetryAnnotation(beforeRetryMethod = "beforeRetry")
    public String call() {
        if (attempt.getAndIncrement() < 1) {
            throw new IllegalStateException();
        }
        return "call " + attempt.get();
    }

    public void beforeRetry() {
        beforeRetryRuns.incrementAndGet();
    }
````

* I ignored all the async logic for now
* I created a very simple test io.smallrye.faulttolerance.before.retry.BeforeRetryTestBean and it's working.