### PR TITLE
revamp async types support

### DIFF
--- a/doc/modules/ROOT/pages/integration/intro.adoc
+++ b/doc/modules/ROOT/pages/integration/intro.adoc
@@ -14,7 +14,6 @@ These artifacts must be always present, together with the following dependencies
 * `org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api`;
 * `org.eclipse.microprofile.config:microprofile-config-api` and some implementation;
 * `org.eclipse.microprofile.metrics:microprofile-metrics-api` and some implementation (implementation is only required if fault tolerance metrics are enabled);
-* `io.smallrye.reactive:smallrye-reactive-converter-api`;
 * `org.jboss.logging:jboss-logging`.
 
 Some other artifacts are provided to facilitate additional integrations.

--- a/doc/modules/ROOT/pages/usage/extra.adoc
+++ b/doc/modules/ROOT/pages/usage/extra.adoc
@@ -175,10 +175,9 @@ We also recommend avoiding `@Asynchronous` methods that return `Future`, because
 
 * Mutiny: `Uni`
 * RxJava: `Single`, `Maybe`, `Completable`
-* Reactor: `Mono`
 
 These types are treated just like `CompletionStage`, so everything that works for `CompletionStage` works for these types as well.
-Stream-like types (`Multi`, `Observable`, `Flowable`, `Flux`) are not supported, because their semantics can't be easily expressed in terms of `CompletionStage`.
+Stream-like types (`Multi`, `Observable`, `Flowable`) are not supported, because their semantics can't be easily expressed in terms of `CompletionStage`.
 
 For example:
 
@@ -198,16 +197,13 @@ public class MyService {
 <2> Returning the `Uni` type from Mutiny.
     This shows that whatever works for `CompletionStage` also works for the other async types.
 
-The implementation is based on the https://github.com/smallrye/smallrye-reactive-utils/tree/main/reactive-converters[SmallRye Reactive Converters] project.
+The implementation internally converts the async types to a `CompletionStage` and back.
 This means that to be able to use any particular asynchronous type, the corresponding converter library must be present.
 It is possible that the runtime you use already provides the correct integration.
 Otherwise, add a dependency to your application:
 
-* https://smallrye.io/smallrye-mutiny/[Mutiny]: `io.smallrye.reactive:smallrye-reactive-converter-mutiny`
-* https://github.com/ReactiveX/RxJava/tree/1.x[RxJava 1]: `io.smallrye.reactive:smallrye-reactive-converter-rxjava1`
-* https://github.com/ReactiveX/RxJava/tree/2.x[RxJava 2]: `io.smallrye.reactive:smallrye-reactive-converter-rxjava2`
-* https://github.com/ReactiveX/RxJava/tree/3.x[RxJava 3]: `io.smallrye.reactive:smallrye-reactive-converter-rxjava3`
-* https://projectreactor.io/[Reactor]: `io.smallrye.reactive:smallrye-reactive-converter-reactor`
+* https://smallrye.io/smallrye-mutiny/[Mutiny]: `io.smallrye:smallrye-fault-tolerance-mutiny`
+* https://github.com/ReactiveX/RxJava/tree/3.x[RxJava 3]: `io.smallrye:smallrye-fault-tolerance-rxjava3`
 
 .Quarkus
 ****

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/types/AsyncTypeConverter.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/types/AsyncTypeConverter.java
@@ -1,0 +1,12 @@
+package io.smallrye.faulttolerance.core.async.types;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+public interface AsyncTypeConverter<V, AT> {
+    Class<?> type();
+
+    AT fromCompletionStage(Supplier<CompletionStage<V>> completionStageSupplier);
+
+    CompletionStage<V> toCompletionStage(AT asyncValue);
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/types/AsyncTypesLogger.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/types/AsyncTypesLogger.java
@@ -1,0 +1,10 @@
+package io.smallrye.faulttolerance.core.async.types;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.MessageLogger;
+
+@MessageLogger(projectCode = "SRFTL", length = 5)
+interface AsyncTypesLogger extends BasicLogger {
+    AsyncTypesLogger LOG = Logger.getMessageLogger(AsyncTypesLogger.class, AsyncTypesLogger.class.getPackage().getName());
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/types/CompletionStageConverter.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/types/CompletionStageConverter.java
@@ -1,0 +1,21 @@
+package io.smallrye.faulttolerance.core.async.types;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+public class CompletionStageConverter<T> implements AsyncTypeConverter<T, CompletionStage<T>> {
+    @Override
+    public Class<?> type() {
+        return CompletionStage.class;
+    }
+
+    @Override
+    public CompletionStage<T> fromCompletionStage(Supplier<CompletionStage<T>> completionStageSupplier) {
+        return completionStageSupplier.get();
+    }
+
+    @Override
+    public CompletionStage<T> toCompletionStage(CompletionStage<T> asyncValue) {
+        return asyncValue;
+    }
+}

--- a/implementation/core/src/main/resources/META-INF/services/io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter
+++ b/implementation/core/src/main/resources/META-INF/services/io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter
@@ -1,0 +1,1 @@
+io.smallrye.faulttolerance.core.async.types.CompletionStageConverter

--- a/implementation/fault-tolerance/pom.xml
+++ b/implementation/fault-tolerance/pom.xml
@@ -74,10 +74,6 @@
             <artifactId>microprofile-metrics-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-converter-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
             <optional>true</optional>

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceInterceptor.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceInterceptor.java
@@ -51,6 +51,7 @@ import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
 import io.smallrye.faulttolerance.core.async.CompletionStageExecution;
 import io.smallrye.faulttolerance.core.async.FutureExecution;
 import io.smallrye.faulttolerance.core.async.RememberEventLoop;
+import io.smallrye.faulttolerance.core.async.types.AsyncTypesConversion;
 import io.smallrye.faulttolerance.core.bulkhead.CompletionStageThreadPoolBulkhead;
 import io.smallrye.faulttolerance.core.bulkhead.FutureThreadPoolBulkhead;
 import io.smallrye.faulttolerance.core.bulkhead.SemaphoreBulkhead;
@@ -84,7 +85,6 @@ import io.smallrye.faulttolerance.core.timer.Timer;
 import io.smallrye.faulttolerance.core.util.DirectExecutor;
 import io.smallrye.faulttolerance.core.util.ExceptionDecision;
 import io.smallrye.faulttolerance.core.util.SetOfThrowables;
-import io.smallrye.faulttolerance.internal.AsyncTypesConversion;
 import io.smallrye.faulttolerance.internal.InterceptionPoint;
 import io.smallrye.faulttolerance.internal.RequestScopeActivator;
 import io.smallrye.faulttolerance.internal.StrategyCache;
@@ -174,7 +174,7 @@ public class FaultToleranceInterceptor {
         try {
             return strategy.apply(ctx);
         } catch (Exception e) {
-            return AsyncTypes.get(operation.getReturnType()).fromCompletionStage(failedStage(e));
+            return AsyncTypes.get(operation.getReturnType()).fromCompletionStage(() -> failedStage(e));
         }
     }
 

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/AsyncValidation.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/AsyncValidation.java
@@ -4,7 +4,7 @@ import java.util.StringJoiner;
 import java.util.concurrent.Future;
 
 import io.smallrye.faulttolerance.AsyncTypes;
-import io.smallrye.reactive.converters.ReactiveTypeConverter;
+import io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter;
 
 final class AsyncValidation {
     static boolean isAcceptableReturnType(Class<?> returnType) {
@@ -13,7 +13,7 @@ final class AsyncValidation {
 
     static String describeKnownAsyncTypes() {
         StringJoiner result = new StringJoiner(" or ");
-        for (ReactiveTypeConverter<?> converter : AsyncTypes.allKnown()) {
+        for (AsyncTypeConverter<?, ?> converter : AsyncTypes.allKnown()) {
             result.add(converter.type().getName());
         }
         return result.toString();

--- a/implementation/mutiny/pom.xml
+++ b/implementation/mutiny/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
+        <version>5.2.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-fault-tolerance-mutiny</artifactId>
+
+    <name>SmallRye Fault Tolerance: Mutiny Integration</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-fault-tolerance-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/implementation/mutiny/src/main/java/io/smallrye/faulttolerance/mutiny/impl/UniConverter.java
+++ b/implementation/mutiny/src/main/java/io/smallrye/faulttolerance/mutiny/impl/UniConverter.java
@@ -1,0 +1,24 @@
+package io.smallrye.faulttolerance.mutiny.impl;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter;
+import io.smallrye.mutiny.Uni;
+
+public class UniConverter<T> implements AsyncTypeConverter<T, Uni<T>> {
+    @Override
+    public Class<?> type() {
+        return Uni.class;
+    }
+
+    @Override
+    public Uni<T> fromCompletionStage(Supplier<CompletionStage<T>> completionStageSupplier) {
+        return Uni.createFrom().completionStage(completionStageSupplier);
+    }
+
+    @Override
+    public CompletionStage<T> toCompletionStage(Uni<T> uni) {
+        return uni.subscribeAsCompletionStage();
+    }
+}

--- a/implementation/mutiny/src/main/resources/META-INF/services/io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter
+++ b/implementation/mutiny/src/main/resources/META-INF/services/io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter
@@ -1,0 +1,1 @@
+io.smallrye.faulttolerance.mutiny.impl.UniConverter

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -30,11 +30,14 @@
 
     <modules>
         <module>core</module>
+        <module>mutiny</module>
+        <module>rxjava3</module>
+        <module>vertx</module>
+
         <module>autoconfig</module>
         <module>fault-tolerance</module>
         <module>context-propagation</module>
         <module>tracing-propagation</module>
-        <module>vertx</module>
 
         <module>standalone</module>
     </modules>

--- a/implementation/rxjava3/pom.xml
+++ b/implementation/rxjava3/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
+        <version>5.2.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-fault-tolerance-rxjava3</artifactId>
+
+    <name>SmallRye Fault Tolerance: RxJava 3 Integration</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-fault-tolerance-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/CompletableConverter.java
+++ b/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/CompletableConverter.java
@@ -1,0 +1,24 @@
+package io.smallrye.faulttolerance.rxjava3.impl;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter;
+
+public class CompletableConverter<T> implements AsyncTypeConverter<T, Completable> {
+    @Override
+    public Class<?> type() {
+        return Completable.class;
+    }
+
+    @Override
+    public Completable fromCompletionStage(Supplier<CompletionStage<T>> completionStageSupplier) {
+        return Completable.defer(() -> Completable.fromCompletionStage(completionStageSupplier.get()));
+    }
+
+    @Override
+    public CompletionStage<T> toCompletionStage(Completable completable) {
+        return completable.toCompletionStage(null);
+    }
+}

--- a/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/MaybeConverter.java
+++ b/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/MaybeConverter.java
@@ -1,0 +1,24 @@
+package io.smallrye.faulttolerance.rxjava3.impl;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter;
+
+public class MaybeConverter<T> implements AsyncTypeConverter<T, Maybe<T>> {
+    @Override
+    public Class<?> type() {
+        return Maybe.class;
+    }
+
+    @Override
+    public Maybe<T> fromCompletionStage(Supplier<CompletionStage<T>> completionStageSupplier) {
+        return Maybe.defer(() -> Maybe.fromCompletionStage(completionStageSupplier.get()));
+    }
+
+    @Override
+    public CompletionStage<T> toCompletionStage(Maybe<T> maybe) {
+        return maybe.toCompletionStage(null);
+    }
+}

--- a/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/SingleConverter.java
+++ b/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/SingleConverter.java
@@ -1,0 +1,24 @@
+package io.smallrye.faulttolerance.rxjava3.impl;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import io.reactivex.rxjava3.core.Single;
+import io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter;
+
+public class SingleConverter<T> implements AsyncTypeConverter<T, Single<T>> {
+    @Override
+    public Class<?> type() {
+        return Single.class;
+    }
+
+    @Override
+    public Single<T> fromCompletionStage(Supplier<CompletionStage<T>> completionStageSupplier) {
+        return Single.defer(() -> Single.fromCompletionStage(completionStageSupplier.get()));
+    }
+
+    @Override
+    public CompletionStage<T> toCompletionStage(Single<T> single) {
+        return single.toCompletionStage();
+    }
+}

--- a/implementation/rxjava3/src/main/resources/META-INF/services/io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter
+++ b/implementation/rxjava3/src/main/resources/META-INF/services/io.smallrye.faulttolerance.core.async.types.AsyncTypeConverter
@@ -1,0 +1,3 @@
+io.smallrye.faulttolerance.rxjava3.impl.SingleConverter
+io.smallrye.faulttolerance.rxjava3.impl.MaybeConverter
+io.smallrye.faulttolerance.rxjava3.impl.CompletableConverter

--- a/implementation/vertx/pom.xml
+++ b/implementation/vertx/pom.xml
@@ -29,10 +29,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-fault-tolerance-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -175,8 +175,8 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-converter-api</artifactId>
-                <version>${version.smallrye-reactive-utils}</version>
+                <artifactId>mutiny</artifactId>
+                <version>${version.mutiny}</version>
             </dependency>
             <dependency>
                 <groupId>io.opentracing</groupId>
@@ -198,6 +198,11 @@
                 <artifactId>opentracing-util</artifactId>
                 <version>${version.opentracing}</version>
                 <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>io.reactivex.rxjava3</groupId>
+                <artifactId>rxjava</artifactId>
+                <version>${version.rxjava3}</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
@@ -321,6 +326,22 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-mutiny</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-rxjava3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-vertx</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -344,11 +365,7 @@
                 <artifactId>smallrye-fault-tolerance-tracing-propagation</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance-vertx</artifactId>
-                <version>${project.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-standalone</artifactId>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -35,6 +35,16 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-fault-tolerance-mutiny</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-fault-tolerance-rxjava3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
             <artifactId>smallrye-fault-tolerance-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -56,29 +66,14 @@
             <artifactId>smallrye-metrics</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
-            <version>${version.mutiny}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
-            <version>${version.rxjava3}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-converter-mutiny</artifactId>
-            <version>${version.smallrye-reactive-utils}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-converter-rxjava3</artifactId>
-            <version>${version.smallrye-reactive-utils}</version>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/types/mutiny/resubscription/HelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/types/mutiny/resubscription/HelloService.java
@@ -1,0 +1,22 @@
+package io.smallrye.faulttolerance.async.types.mutiny.resubscription;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class HelloService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @NonBlocking
+    @Retry
+    public Uni<String> hello() {
+        COUNTER.incrementAndGet();
+        return Uni.createFrom().failure(IllegalArgumentException::new);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/types/mutiny/resubscription/MutinyResubscriptionTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/types/mutiny/resubscription/MutinyResubscriptionTest.java
@@ -1,0 +1,25 @@
+package io.smallrye.faulttolerance.async.types.mutiny.resubscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.mutiny.Uni;
+
+@FaultToleranceBasicTest
+public class MutinyResubscriptionTest {
+    // this test verifies resubscription, which is triggered via retry
+
+    @Test
+    public void test(HelloService service) {
+        Uni<String> hello = service.hello()
+                .onFailure().retry().atMost(2)
+                .onFailure().recoverWithItem("hello");
+        assertThat(hello.await().indefinitely()).isEqualTo("hello");
+
+        // the service.hello() method has @Retry with default settings, so 1 initial attempt + 3 retries = 4 total
+        // the onFailure().retry() handler does 1 initial attempt + 2 retries = 3 total
+        assertThat(HelloService.COUNTER).hasValue(4 * 3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/types/rxjava/resubscription/HelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/types/rxjava/resubscription/HelloService.java
@@ -1,0 +1,22 @@
+package io.smallrye.faulttolerance.async.types.rxjava.resubscription;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.smallrye.common.annotation.NonBlocking;
+
+@ApplicationScoped
+public class HelloService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @NonBlocking
+    @Retry
+    public Maybe<String> hello() {
+        COUNTER.incrementAndGet();
+        return Maybe.error(IllegalArgumentException::new);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/types/rxjava/resubscription/RxjavaResubscriptionTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/types/rxjava/resubscription/RxjavaResubscriptionTest.java
@@ -1,0 +1,25 @@
+package io.smallrye.faulttolerance.async.types.rxjava.resubscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class RxjavaResubscriptionTest {
+    // this test verifies resubscription, which is triggered via retry
+
+    @Test
+    public void test(HelloService service) {
+        Maybe<String> hello = service.hello()
+                .retry(2)
+                .onErrorReturnItem("hello");
+        assertThat(hello.blockingGet()).isEqualTo("hello");
+
+        // the service.hello() method has @Retry with default settings, so 1 initial attempt + 3 retries = 4 total
+        // the retry() handler does 1 initial attempt + 2 retries = 3 total
+        assertThat(HelloService.COUNTER).hasValue(4 * 3);
+    }
+}


### PR DESCRIPTION
This commit moves from SmallRye Reactive Converters to a built-in
async type conversion facility. This new conversion library enforces
that the async type is not created from a `CompletionStage` (which
is eager and hence already running), but from a `Supplier` of
`CompletionStage`. Hence, lazy async types may be created as truly
lazy, and if they allow resubscription, that works properly.
Tests for resubscription are added both for Mutiny and RxJava 3.

SmallRye Reactive Converters supported Mutiny, all RxJava major
versions, and Reactor. The built-in library supports Mutiny and
RxJava 3, which I believe is enough. Adding support for Reactor
would be trivial, but doesn't seem necessary at this point.

Resolves #504