### PR TITLE
get rid of JUnit Pioneer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <version.assertj>3.22.0</version.assertj>
         <version.awaitility>4.2.0</version.awaitility>
         <version.junit-jupiter>5.8.2</version.junit-jupiter>
-        <version.junit-pioneer>1.6.2</version.junit-pioneer>
         <version.mutiny>1.4.0</version.mutiny>
         <version.rxjava3>3.1.4</version.rxjava3>
         <version.testng>6.14.3</version.testng>
@@ -309,12 +308,6 @@
                 <version>${version.junit-jupiter}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit-pioneer</groupId>
-                <artifactId>junit-pioneer</artifactId>
-                <version>${version.junit-pioneer}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -103,11 +103,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit-pioneer</groupId>
-            <artifactId>junit-pioneer</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/noncompatible/NoncompatibleNonblockingAsyncTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/noncompatible/NoncompatibleNonblockingAsyncTest.java
@@ -7,14 +7,14 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
 
 @FaultToleranceBasicTest
 public class NoncompatibleNonblockingAsyncTest {
     @Test
-    @SetSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
     public void noncompatibleMode(NoncompatibleNonblockingHelloService service) throws Exception {
         Thread mainThread = Thread.currentThread();
 
@@ -30,7 +30,7 @@ public class NoncompatibleNonblockingAsyncTest {
     }
 
     @Test
-    @SetSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
     public void explicitCompatibleMode(NoncompatibleNonblockingHelloService service) {
         CompletionStage<String> future = service.hello();
         assertThatThrownBy(() -> future.toCompletableFuture().get())

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/sizing/AsyncThreadPoolSizingOldConfigTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/sizing/AsyncThreadPoolSizingOldConfigTest.java
@@ -1,11 +1,10 @@
 package io.smallrye.faulttolerance.async.sizing;
 
-import org.junitpioneer.jupiter.SetSystemProperty;
-
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
 
-@SetSystemProperty(key = "io.smallrye.faulttolerance.globalThreadPoolSize", value = "10")
-@SetSystemProperty(key = "io.smallrye.faulttolerance.mainThreadPoolQueueSize", value = "0")
+@WithSystemProperty(key = "io.smallrye.faulttolerance.globalThreadPoolSize", value = "10")
+@WithSystemProperty(key = "io.smallrye.faulttolerance.mainThreadPoolQueueSize", value = "0")
 @FaultToleranceBasicTest
 public class AsyncThreadPoolSizingOldConfigTest extends AbstractAsyncThreadPoolSizingTest {
 }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/sizing/AsyncThreadPoolSizingTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/sizing/AsyncThreadPoolSizingTest.java
@@ -1,11 +1,10 @@
 package io.smallrye.faulttolerance.async.sizing;
 
-import org.junitpioneer.jupiter.SetSystemProperty;
-
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
 
-@SetSystemProperty(key = "io.smallrye.faulttolerance.mainThreadPoolSize", value = "10")
-@SetSystemProperty(key = "io.smallrye.faulttolerance.mainThreadPoolQueueSize", value = "0")
+@WithSystemProperty(key = "io.smallrye.faulttolerance.mainThreadPoolSize", value = "10")
+@WithSystemProperty(key = "io.smallrye.faulttolerance.mainThreadPoolQueueSize", value = "0")
 @FaultToleranceBasicTest
 public class AsyncThreadPoolSizingTest extends AbstractAsyncThreadPoolSizingTest {
 }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/maintenance/CircuitBreakerMaintenanceInteroperabilityTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/maintenance/CircuitBreakerMaintenanceInteroperabilityTest.java
@@ -13,17 +13,17 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 import io.smallrye.faulttolerance.api.CircuitBreakerMaintenance;
 import io.smallrye.faulttolerance.api.CircuitBreakerState;
 import io.smallrye.faulttolerance.api.FaultTolerance;
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
 
 @FaultToleranceBasicTest
 // Weld SE by default enables relaxed client proxy instantiation, which is different from
 // all other environments and pretty crucial for this test
-@SetSystemProperty(key = "org.jboss.weld.construction.relaxed", value = "false")
+@WithSystemProperty(key = "org.jboss.weld.construction.relaxed", value = "false")
 public class CircuitBreakerMaintenanceInteroperabilityTest {
     @Inject
     private HelloService helloService;

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/config/priority/ConfigParameterPriorityTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/config/priority/ConfigParameterPriorityTest.java
@@ -24,13 +24,13 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.jboss.weld.junit5.auto.AddBeanClasses;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 import io.smallrye.faulttolerance.FaultToleranceOperations;
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
 
-@SetSystemProperty(key = "Retry/delay", value = "10")
+@WithSystemProperty(key = "Retry/delay", value = "10")
 @FaultToleranceBasicTest
 @AddBeanClasses(FaultyService.class)
 public class ConfigParameterPriorityTest {

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/fallback/causechain/FallbackWithExceptionCauseChainTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/fallback/causechain/FallbackWithExceptionCauseChainTest.java
@@ -5,11 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
 
-@SetSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+@WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
 @FaultToleranceBasicTest
 public class FallbackWithExceptionCauseChainTest {
     @Test

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/programmatic/CdiSkipFaultToleranceTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/programmatic/CdiSkipFaultToleranceTest.java
@@ -6,16 +6,16 @@ import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 import io.smallrye.faulttolerance.api.FaultTolerance;
 import io.smallrye.faulttolerance.core.util.TestException;
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
 
 // we boot a new Weld container for each test, so the config property will be read again
 // this is impossible for the standalone implementation (unless we forked the JVM for each test)
 @FaultToleranceBasicTest
-@SetSystemProperty(key = "MP_Fault_Tolerance_NonFallback_Enabled", value = "false")
+@WithSystemProperty(key = "MP_Fault_Tolerance_NonFallback_Enabled", value = "false")
 public class CdiSkipFaultToleranceTest {
     private int counter;
 

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/retry/backoff/exponential/config/ConfiguredExponentialBackoffRetryTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/retry/backoff/exponential/config/ConfiguredExponentialBackoffRetryTest.java
@@ -8,12 +8,12 @@ import javax.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
 
 @FaultToleranceBasicTest
-@SetSystemProperty(key = "io.smallrye.faulttolerance.retry.backoff.exponential.config.ConfiguredExponentialBackoffRetryService/hello/ExponentialBackoff/factor", value = "3")
+@WithSystemProperty(key = "io.smallrye.faulttolerance.retry.backoff.exponential.config.ConfiguredExponentialBackoffRetryService/hello/ExponentialBackoff/factor", value = "3")
 @EnabledOnOs(OS.LINUX)
 public class ConfiguredExponentialBackoffRetryTest {
     @Inject

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/util/WithSystemProperty.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/util/WithSystemProperty.java
@@ -1,0 +1,25 @@
+package io.smallrye.faulttolerance.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Repeatable(WithSystemProperty.List.class)
+@ExtendWith(WithSystemPropertyExtension.class)
+public @interface WithSystemProperty {
+    String key();
+
+    String value();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @interface List {
+        WithSystemProperty[] value();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/util/WithSystemPropertyExtension.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/util/WithSystemPropertyExtension.java
@@ -1,0 +1,92 @@
+package io.smallrye.faulttolerance.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+public class WithSystemPropertyExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        apply(context);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        apply(context);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        unapply(context);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        unapply(context);
+    }
+
+    private static void apply(ExtensionContext context) {
+        Map<String, String> map = AnnotationSupport.findRepeatableAnnotations(context.getElement(), WithSystemProperty.class)
+                .stream()
+                .collect(Collectors.toMap(WithSystemProperty::key, WithSystemProperty::value));
+
+        getStore(context).put(getStoreKey(context), new Backup(map.keySet()));
+
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            System.setProperty(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private static void unapply(ExtensionContext context) {
+        Backup backup = getStore(context).getOrDefault(getStoreKey(context), Backup.class, Backup.empty());
+        backup.restore();
+    }
+
+    private static ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(WithSystemPropertyExtension.class));
+    }
+
+    private static Object getStoreKey(ExtensionContext context) {
+        return context.getUniqueId();
+    }
+
+    private static class Backup {
+        private final Set<String> toClear = new HashSet<>();
+        private final Map<String, String> toReset = new HashMap<>();
+
+        static Backup empty() {
+            return new Backup(Collections.emptySet());
+        }
+
+        Backup(Set<String> keys) {
+            for (String key : keys) {
+                String value = System.getProperty(key);
+                if (value == null) {
+                    toClear.add(key);
+                } else {
+                    toReset.put(key, value);
+                }
+            }
+        }
+
+        public void restore() {
+            for (String key : toClear) {
+                System.clearProperty(key);
+            }
+            for (Map.Entry<String, String> entry : toReset.entrySet()) {
+                System.setProperty(entry.getKey(), entry.getValue());
+            }
+        }
+
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/bulkhead/KotlinBulkheadTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/bulkhead/KotlinBulkheadTest.kt
@@ -1,14 +1,14 @@
 package io.smallrye.faulttolerance.kotlin.bulkhead
 
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import io.smallrye.faulttolerance.util.WithSystemProperty
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junitpioneer.jupiter.SetSystemProperty
 
 // so that FT methods don't have to be marked @NonBlocking
-@SetSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+@WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
 @FaultToleranceBasicTest
 class KotlinBulkheadTest {
     private val tasks = 20_000

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/circuitbreaker/KotlinCircuitBreakerTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/circuitbreaker/KotlinCircuitBreakerTest.kt
@@ -1,16 +1,16 @@
 package io.smallrye.faulttolerance.kotlin.circuitbreaker
 
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import io.smallrye.faulttolerance.util.WithSystemProperty
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException
 import org.junit.jupiter.api.Test
-import org.junitpioneer.jupiter.SetSystemProperty
 import java.io.IOException
 
 // so that FT methods don't have to be marked @NonBlocking
-@SetSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+@WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
 @FaultToleranceBasicTest
 class KotlinCircuitBreakerTest {
     @Test

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/retry/KotlinRetryTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/retry/KotlinRetryTest.kt
@@ -1,13 +1,13 @@
 package io.smallrye.faulttolerance.kotlin.retry
 
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import io.smallrye.faulttolerance.util.WithSystemProperty
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junitpioneer.jupiter.SetSystemProperty
 
 // so that FT methods don't have to be marked @NonBlocking
-@SetSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+@WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
 @FaultToleranceBasicTest
 class KotlinRetryTest {
     @Test

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/timeout/KotlinTimeoutTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/timeout/KotlinTimeoutTest.kt
@@ -1,13 +1,13 @@
 package io.smallrye.faulttolerance.kotlin.timeout
 
 import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import io.smallrye.faulttolerance.util.WithSystemProperty
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junitpioneer.jupiter.SetSystemProperty
 
 // so that FT methods don't have to be marked @NonBlocking
-@SetSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+@WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
 @FaultToleranceBasicTest
 class KotlinTimeoutTest {
     @Test

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -81,11 +81,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit-pioneer</groupId>
-            <artifactId>junit-pioneer</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
The `@SetSystemProprety` annotation/extension from JUnit Pioneer
was used on a couple places to change MP Config configuration.
In version 1.7.0, JUnit Pioneer makes a breaking change and
class-level annotations are now handled as method-level annotations
present on all methods, which leads to some tests failing
because MP Config configuration isn't changed early enough.

(An implicit assumption is made that class-level annotations
roughly correspond to the `{Before,After}AllCallback` extension
points of JUnit Jupiter, while method-level annotations roughly
correspond to the `{Before,After}EachCallback` extension points.
This assumption is, in my opinion, rather intuitive.)

In this commit, `@SetSystemProperty` from JUnit Pioneer is replaced
with our own `@WithSystemProperty` that behaves the original way.
Since this was the only usage of JUnit Pioneer, the dependency
on JUnit Pioneer is removed.