### PR TITLE
work around RetryTest.testClassLevelRetryMaxDuration TCK failures on macOS

### DIFF
--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -63,6 +63,12 @@
                     <systemPropertyVariables>
                         <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>
                     </systemPropertyVariables>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>io.smallrye.faulttolerance.tck.LoggingTestListener</value>
+                        </property>
+                    </properties>
                 </configuration>
                 <executions>
                     <execution>

--- a/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/FaultToleranceExtension.java
+++ b/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/FaultToleranceExtension.java
@@ -28,6 +28,7 @@ public class FaultToleranceExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
         builder.service(ApplicationArchiveProcessor.class, FaultToleranceApplicationArchiveProcessor.class);
+        builder.service(ApplicationArchiveProcessor.class, RetryTckOnMac.class);
         builder.service(DeploymentExceptionTransformer.class, TckDeploymentExceptionTransformer.class);
         builder.observer(CleanupMetricRegistries.class);
     }

--- a/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/LoggingTestListener.java
+++ b/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/LoggingTestListener.java
@@ -1,0 +1,42 @@
+package io.smallrye.faulttolerance.tck;
+
+import org.jboss.logging.Logger;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+public class LoggingTestListener implements ITestListener {
+    private static final Logger LOG = Logger.getLogger(LoggingTestListener.class);
+
+    @Override
+    public void onTestStart(ITestResult result) {
+        LOG.info("Starting " + result.getTestClass().getName() + "#" + result.getMethod().getMethodName());
+    }
+
+    @Override
+    public void onTestSuccess(ITestResult result) {
+        LOG.info("Succeeded " + result.getTestClass().getName() + "#" + result.getMethod().getMethodName());
+    }
+
+    @Override
+    public void onTestFailure(ITestResult result) {
+        LOG.info("Failed " + result.getTestClass().getName() + "#" + result.getMethod().getMethodName());
+    }
+
+    @Override
+    public void onTestSkipped(ITestResult result) {
+        LOG.info("Skipped " + result.getTestClass().getName() + "#" + result.getMethod().getMethodName());
+    }
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+    }
+
+    @Override
+    public void onStart(ITestContext context) {
+    }
+
+    @Override
+    public void onFinish(ITestContext context) {
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/RetryTckOnMac.java
+++ b/testsuite/tck/src/test/java/io/smallrye/faulttolerance/tck/RetryTckOnMac.java
@@ -1,0 +1,37 @@
+package io.smallrye.faulttolerance.tck;
+
+import java.util.Locale;
+
+import org.eclipse.microprofile.fault.tolerance.tck.RetryTest;
+import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
+import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClassLevelClientForMaxRetries;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+public class RetryTckOnMac implements ApplicationArchiveProcessor {
+    // TODO
+    //  The `RetryTest.testClassLevelRetryMaxDuration` TCK test often fails in CI on the macOS machines.
+    //  This is because the test doesn't properly scale delays and timeouts, unlike majority of the tests
+    //  in the TCK, and `Thread.sleep(100)` often takes roughly 200 millis on the macOS machines in CI.
+    //  Here, we work around that problem by reducing jitter on the affected method to 0, thereby significantly
+    //  reducing the impact of the `Thread.sleep()` slowdown.
+
+    @Override
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+        if (isMac() && RetryTest.class.getName().equals(testClass.getName())) {
+            ConfigAnnotationAsset config = (ConfigAnnotationAsset) applicationArchive
+                    .getAsType(JavaArchive.class, "/WEB-INF/lib/ftRetry.jar")
+                    .get("/META-INF/microprofile-config.properties")
+                    .getAsset();
+            config.set(RetryClassLevelClientForMaxRetries.class, "serviceB", Retry.class, "jitter", "0");
+        }
+    }
+
+    private boolean isMac() {
+        String os = System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT);
+        return os.contains("mac") || os.contains("darwin");
+    }
+}


### PR DESCRIPTION
This commit also adds TCK progress logging in the form of a TestNG
listener, enabled in the POM.

Fixes #448