### PR TITLE
Allow outside visibility into effective fault tolerance configuration

### DIFF
--- a/doc/modules/ROOT/pages/integration/intro.adoc
+++ b/doc/modules/ROOT/pages/integration/intro.adoc
@@ -28,6 +28,7 @@ The remaining integration concerns are described in the following sections:
 * xref:integration/opentracing.adoc[enabling OpenTracing integration] with Context Propagation;
 * xref:integration/event-loop.adoc[integrating an event loop] for non-blocking method invocations;
 * xref:integration/async-types.adoc[integrating additional types] for asynchronous invocations;
+* xref:integration/kotlin.adoc[integrating Kotlin support] for `suspend` functions;
 * xref:integration/programmatic-api.adoc[integrating the programmatic API] that {smallrye-fault-tolerance} provides.
 
 == Standalone Implementation of the Programmatic API

--- a/implementation/autoconfig/core/src/main/java/io/smallrye/faulttolerance/autoconfig/Config.java
+++ b/implementation/autoconfig/core/src/main/java/io/smallrye/faulttolerance/autoconfig/Config.java
@@ -33,6 +33,12 @@ public interface Config {
      */
     boolean isOnMethod();
 
+    /**
+     * Ensures this configuration is loaded. Subsequent method invocations on this instance
+     * are guaranteed to not touch MP Config.
+     */
+    void materialize();
+
     // ---
 
     static <A extends Annotation> boolean isEnabled(Class<A> annotationType, MethodDescriptor method) {

--- a/implementation/autoconfig/processor/src/main/java/io/smallrye/faulttolerance/autoconfig/processor/AutoConfigProcessor.java
+++ b/implementation/autoconfig/processor/src/main/java/io/smallrye/faulttolerance/autoconfig/processor/AutoConfigProcessor.java
@@ -217,6 +217,12 @@ public class AutoConfigProcessor extends AbstractProcessor {
                                         "/", annotationDeclaration.getSimpleName())
                                 .build())
                         : Collections.emptyList())
+                .addMethod(MethodSpec.methodBuilder("materialize")
+                        .addAnnotation(Override.class)
+                        .addModifiers(Modifier.PUBLIC)
+                        .returns(TypeName.VOID)
+                        .addCode(generateMaterializeMethod(annotationDeclaration))
+                        .build())
                 .build())
                 .indent("    ") // 4 spaces
                 .build()
@@ -259,6 +265,14 @@ public class AutoConfigProcessor extends AbstractProcessor {
         return CodeBlock.builder()
                 .addStatement("return instance.$1L()", annotationMember.getSimpleName())
                 .build();
+    }
+
+    private CodeBlock generateMaterializeMethod(TypeElement annotationDeclaration) {
+        CodeBlock.Builder builder = CodeBlock.builder();
+        for (ExecutableElement annotationElement : ElementFilter.methodsIn(annotationDeclaration.getEnclosedElements())) {
+            builder.addStatement("$L()", annotationElement.getSimpleName());
+        }
+        return builder.build();
     }
 
     private static TypeName rawType(TypeMirror type) {

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceOperation.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceOperation.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
@@ -28,6 +29,8 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.faulttolerance.api.ApplyFaultTolerance;
 import io.smallrye.faulttolerance.api.CircuitBreakerName;
 import io.smallrye.faulttolerance.api.CustomBackoff;
@@ -127,6 +130,14 @@ public class FaultToleranceOperation {
         this.customBackoff = customBackoff;
     }
 
+    public Class<?> getBeanClass() {
+        return beanClass;
+    }
+
+    public MethodDescriptor getMethodDescriptor() {
+        return methodDescriptor;
+    }
+
     public Class<?>[] getParameterTypes() {
         return methodDescriptor.parameterTypes;
     }
@@ -147,12 +158,24 @@ public class FaultToleranceOperation {
         return asynchronous != null;
     }
 
+    public Asynchronous getAsynchronous() {
+        return asynchronous;
+    }
+
     public boolean hasBlocking() {
         return blocking != null;
     }
 
+    public Blocking getBlocking() {
+        return blocking;
+    }
+
     public boolean hasNonBlocking() {
         return nonBlocking != null;
+    }
+
+    public NonBlocking getNonBlocking() {
+        return nonBlocking;
     }
 
     // if the guarded method doesn't return CompletionStage, this is meaningless
@@ -342,6 +365,52 @@ public class FaultToleranceOperation {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Ensures all configuration of this fault tolerance operation is loaded. Subsequent method invocations
+     * on this instance are guaranteed to not touch MP Config.
+     */
+    public void materialize() {
+        if (applyFaultTolerance != null) {
+            applyFaultTolerance.materialize();
+        }
+        if (asynchronous != null) {
+            asynchronous.materialize();
+        }
+        if (blocking != null) {
+            blocking.materialize();
+        }
+        if (nonBlocking != null) {
+            nonBlocking.materialize();
+        }
+        if (bulkhead != null) {
+            bulkhead.materialize();
+        }
+        if (circuitBreaker != null) {
+            circuitBreaker.materialize();
+        }
+        if (circuitBreakerName != null) {
+            circuitBreakerName.materialize();
+        }
+        if (fallback != null) {
+            fallback.materialize();
+        }
+        if (retry != null) {
+            retry.materialize();
+        }
+        if (timeout != null) {
+            timeout.materialize();
+        }
+        if (exponentialBackoff != null) {
+            exponentialBackoff.materialize();
+        }
+        if (fibonacciBackoff != null) {
+            fibonacciBackoff.materialize();
+        }
+        if (customBackoff != null) {
+            customBackoff.materialize();
         }
     }
 


### PR DESCRIPTION
This commit:

- allows immediate materialization of fault tolerace configuration;
- provides access to some previously hidden configuration objects.

Additionally, it adds a missing item in the integration documentation
table of contents.