### PR TITLE
avoid explicitly setting metric type for MicroProfile Metrics

### DIFF
--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/MicroProfileMetricsProvider.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/MicroProfileMetricsProvider.java
@@ -20,7 +20,6 @@ import javax.inject.Singleton;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
@@ -34,19 +33,16 @@ import io.smallrye.faulttolerance.core.metrics.MetricsRecorder;
 public class MicroProfileMetricsProvider implements MetricsProvider {
     static final Metadata TIMEOUT_EXECUTION_DURATION_METADATA = Metadata.builder()
             .withName(MetricConstants.TIMEOUT_EXECUTION_DURATION)
-            .withType(MetricType.HISTOGRAM)
             .withUnit(MetricUnits.NANOSECONDS)
             .build();
 
     static final Metadata BULKHEAD_RUNNING_DURATION_METADATA = Metadata.builder()
             .withName(MetricConstants.BULKHEAD_RUNNING_DURATION)
-            .withType(MetricType.HISTOGRAM)
             .withUnit(MetricUnits.NANOSECONDS)
             .build();
 
     static final Metadata BULKHEAD_WAITING_DURATION_METADATA = Metadata.builder()
             .withName(MetricConstants.BULKHEAD_WAITING_DURATION)
-            .withType(MetricType.HISTOGRAM)
             .withUnit(MetricUnits.NANOSECONDS)
             .build();
 
@@ -176,7 +172,6 @@ public class MicroProfileMetricsProvider implements MetricsProvider {
         private void registerGauge(Supplier<Long> supplier, String name, String unit, Tag... tags) {
             Metadata metadata = Metadata.builder()
                     .withName(name)
-                    .withType(MetricType.GAUGE)
                     .withUnit(unit)
                     .build();
             registry.gauge(metadata, supplier, tags);


### PR DESCRIPTION
Per the MP Metrics specification, if a `Metadata` object is constructed without the metric type and then used to create a metric of a specific type using `MetricRegistry` methods (such as `counter` or `gauge`), the metric type is set automatically. Since the `MicroProfileMetricsProvider` always uses the specific `MetricRegistry` methods (and never the generic method `register`), setting the metric type in `Metadata` is not necessary.

Further, MP Metrics 5.0 removes the notion of `MetricType` altogether, but the rest of the `Metadata` API remains intact. This commit makes porting SmallRye Fault Tolerance to MP Metrics 5.0 much easier.