### PR TITLE
fix circuit breaker state transitions

### DIFF
--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
@@ -266,7 +266,8 @@ public final class FaultToleranceImpl<V, S, T> implements FaultTolerance<T> {
                         circuitBreakerBuilder.requestVolumeThreshold,
                         circuitBreakerBuilder.failureRatio,
                         circuitBreakerBuilder.successThreshold,
-                        SystemStopwatch.INSTANCE);
+                        SystemStopwatch.INSTANCE,
+                        lazyDependencies.timer());
 
                 if (circuitBreakerBuilder.name != null) {
                     CircuitBreaker<?> circuitBreaker = (CircuitBreaker<?>) result;
@@ -328,7 +329,8 @@ public final class FaultToleranceImpl<V, S, T> implements FaultTolerance<T> {
                         circuitBreakerBuilder.requestVolumeThreshold,
                         circuitBreakerBuilder.failureRatio,
                         circuitBreakerBuilder.successThreshold,
-                        SystemStopwatch.INSTANCE);
+                        SystemStopwatch.INSTANCE,
+                        lazyDependencies.timer());
 
                 if (circuitBreakerBuilder.name != null) {
                     CircuitBreaker<?> circuitBreaker = (CircuitBreaker<?>) result;

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/circuit/breaker/CircuitBreaker.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/circuit/breaker/CircuitBreaker.java
@@ -13,6 +13,7 @@ import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
 import io.smallrye.faulttolerance.core.InvocationContext;
 import io.smallrye.faulttolerance.core.stopwatch.RunningStopwatch;
 import io.smallrye.faulttolerance.core.stopwatch.Stopwatch;
+import io.smallrye.faulttolerance.core.timer.Timer;
 import io.smallrye.faulttolerance.core.util.ExceptionDecision;
 
 public class CircuitBreaker<V> implements FaultToleranceStrategy<V> {
@@ -29,18 +30,20 @@ public class CircuitBreaker<V> implements FaultToleranceStrategy<V> {
     final int failureThreshold;
     final int successThreshold;
     final Stopwatch stopwatch;
+    final Timer timer;
 
     final AtomicReference<State> state;
 
     public CircuitBreaker(FaultToleranceStrategy<V> delegate, String description, ExceptionDecision exceptionDecision,
             long delayInMillis, int requestVolumeThreshold, double failureRatio, int successThreshold,
-            Stopwatch stopwatch) {
+            Stopwatch stopwatch, Timer timer) {
         this.delegate = checkNotNull(delegate, "Circuit breaker delegate must be set");
         this.description = checkNotNull(description, "Circuit breaker description must be set");
         this.exceptionDecision = checkNotNull(exceptionDecision, "Exception decision must be set");
         this.delayInMillis = check(delayInMillis, delayInMillis >= 0, "Circuit breaker delay must be >= 0");
         this.successThreshold = check(successThreshold, successThreshold > 0, "Circuit breaker success threshold must be > 0");
         this.stopwatch = checkNotNull(stopwatch, "Stopwatch must be set");
+        this.timer = checkNotNull(timer, "Timer must be set");
         this.failureThreshold = check((int) Math.ceil(failureRatio * requestVolumeThreshold),
                 failureRatio >= 0.0 && failureRatio <= 1.0,
                 "Circuit breaker rolling window failure ratio must be >= 0 && <= 1");
@@ -111,7 +114,7 @@ public class CircuitBreaker<V> implements FaultToleranceStrategy<V> {
             ctx.fireEvent(CircuitBreakerEvents.Finished.PREVENTED);
             throw new CircuitBreakerOpenException(description + " circuit breaker is open");
         } else {
-            LOG.trace("Delay elapsed, circuit breaker moving to half-open");
+            LOG.trace("Delay elapsed synchronously, circuit breaker moving to half-open");
             toHalfOpen(ctx, state);
             // start over to re-read current state; no hard guarantee that it's HALF_OPEN at this point
             return doApply(ctx);
@@ -166,6 +169,25 @@ public class CircuitBreaker<V> implements FaultToleranceStrategy<V> {
 
         if (moved) {
             ctx.fireEvent(CircuitBreakerEvents.StateTransition.TO_OPEN);
+
+            // this is not necessary for correct functioning of the circuit breaker itself, because
+            // all the necessary state transitions happen synchronously (during invocations)
+            //
+            // that, however, isn't enough for correct functioning of _external observers_ of
+            // the circuit breaker state
+            //
+            // note that:
+            // 1. the timer task created below and the circuit breaker invocations compete on
+            //    changing the state, but that doesn't pose a problem, because it is an atomic CAS
+            // 2. there's some overhead from having both synchronous and asynchronous state changes,
+            //    but it's minuscule (see what `toHalfOpen` does)
+            // 3. this asynchronous state transition fires the event to an _old_ `InvocationContext`,
+            //    so if there's an event handler registered _after_ this circuit breaker invocation,
+            //    it will _not_ be called (I don't think that's a problem, frankly)
+            timer.schedule(delayInMillis, () -> {
+                LOG.trace("Delay elapsed asynchronously, circuit breaker moving to half-open");
+                toHalfOpen(ctx, newState);
+            });
         }
     }
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/circuit/breaker/CompletionStageCircuitBreaker.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/circuit/breaker/CompletionStageCircuitBreaker.java
@@ -11,15 +11,16 @@ import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenExce
 import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
 import io.smallrye.faulttolerance.core.InvocationContext;
 import io.smallrye.faulttolerance.core.stopwatch.Stopwatch;
+import io.smallrye.faulttolerance.core.timer.Timer;
 import io.smallrye.faulttolerance.core.util.ExceptionDecision;
 
 public class CompletionStageCircuitBreaker<V> extends CircuitBreaker<CompletionStage<V>> {
 
     public CompletionStageCircuitBreaker(FaultToleranceStrategy<CompletionStage<V>> delegate, String description,
             ExceptionDecision exceptionDecision, long delayInMillis, int requestVolumeThreshold, double failureRatio,
-            int successThreshold, Stopwatch stopwatch) {
+            int successThreshold, Stopwatch stopwatch, Timer timer) {
         super(delegate, description, exceptionDecision, delayInMillis, requestVolumeThreshold, failureRatio, successThreshold,
-                stopwatch);
+                stopwatch, timer);
     }
 
     @Override
@@ -79,7 +80,7 @@ public class CompletionStageCircuitBreaker<V> extends CircuitBreaker<CompletionS
             ctx.fireEvent(CircuitBreakerEvents.Finished.PREVENTED);
             return failedStage(new CircuitBreakerOpenException(description + " circuit breaker is open"));
         } else {
-            LOG.trace("Delay elapsed, circuit breaker moving to half-open");
+            LOG.trace("Delay elapsed synchronously, circuit breaker moving to half-open");
             toHalfOpen(ctx, state);
             // start over to re-read current state; no hard guarantee that it's HALF_OPEN at this point
             return doApply(ctx);

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/ThreadTimer.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/ThreadTimer.java
@@ -1,0 +1,172 @@
+package io.smallrye.faulttolerance.core.timer;
+
+import static io.smallrye.faulttolerance.core.timer.TimerLogger.LOG;
+import static io.smallrye.faulttolerance.core.util.Preconditions.checkNotNull;
+
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.SortedSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.Consumer;
+
+import io.smallrye.faulttolerance.core.util.RunnableWrapper;
+
+/**
+ * Starts one thread that processes submitted tasks in a loop and when it's time for a task to run,
+ * it gets submitted to the executor. The default executor is provided by a caller, so the caller
+ * must shut down this timer <em>before</em> shutting down the executor.
+ */
+// TODO implement a hashed wheel?
+public final class ThreadTimer implements Timer {
+    private static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    private static final Comparator<Task> TASK_COMPARATOR = (o1, o2) -> {
+        if (o1 == o2) {
+            // two different instances are never equal
+            return 0;
+        }
+
+        // must _not_ return 0 if start times are equal, because that isn't consistent
+        // with `equals` (see also above)
+        return o1.startTime <= o2.startTime ? -1 : 1;
+    };
+
+    private final String name;
+
+    private final SortedSet<Task> tasks;
+
+    private final Thread thread;
+
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
+    /**
+     * @param defaultExecutor default {@link Executor} used for running scheduled tasks, unless an executor
+     *        is provided when {@linkplain #schedule(long, Runnable, Executor) scheduling} a task
+     */
+    public ThreadTimer(Executor defaultExecutor) {
+        checkNotNull(defaultExecutor, "Executor must be set");
+
+        this.name = "SmallRye Fault Tolerance Timer " + COUNTER.incrementAndGet();
+        LOG.createdTimer(name);
+
+        this.tasks = new ConcurrentSkipListSet<>(TASK_COMPARATOR);
+        this.thread = new Thread(() -> {
+            while (running.get()) {
+                try {
+                    if (tasks.isEmpty()) {
+                        LockSupport.park();
+                    } else {
+                        Task task;
+                        try {
+                            task = tasks.first();
+                        } catch (NoSuchElementException e) {
+                            // can happen if all tasks are cancelled right between `tasks.isEmpty` and `tasks.first`
+                            continue;
+                        }
+
+                        long currentTime = System.nanoTime();
+                        long taskStartTime = task.startTime;
+
+                        // must _not_ use `taskStartTime <= currentTime`, because `System.nanoTime()`
+                        // is relative to an arbitrary number and so it can possibly overflow;
+                        // in such case, `taskStartTime` can be positive, `currentTime` can be negative,
+                        //  and yet `taskStartTime` is _before_ `currentTime`
+                        if (taskStartTime - currentTime <= 0) {
+                            tasks.remove(task);
+                            if (task.state.compareAndSet(Task.STATE_NEW, Task.STATE_RUNNING)) {
+                                Executor executorForTask = task.executorOverride;
+                                if (executorForTask == null) {
+                                    executorForTask = defaultExecutor;
+                                }
+
+                                executorForTask.execute(() -> {
+                                    LOG.runningTimerTask(task);
+                                    try {
+                                        task.runnable.run();
+                                    } finally {
+                                        task.state.set(Task.STATE_FINISHED);
+                                    }
+                                });
+                            }
+                        } else {
+                            // this is OK even if another timer is scheduled during the sleep (even if that timer should
+                            // fire sooner than `taskStartTime`), because `schedule` always calls` LockSupport.unpark`
+                            LockSupport.parkNanos(taskStartTime - currentTime);
+                        }
+                    }
+                } catch (Exception e) {
+                    // can happen e.g. when the executor is shut down sooner than the timer
+                    LOG.unexpectedExceptionInTimerLoop(e);
+                }
+            }
+        }, name);
+        thread.start();
+    }
+
+    @Override
+    public TimerTask schedule(long delayInMillis, Runnable task) {
+        return schedule(delayInMillis, task, null);
+    }
+
+    @Override
+    public TimerTask schedule(long delayInMillis, Runnable task, Executor executor) {
+        long startTime = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayInMillis);
+        Task timerTask = new Task(startTime, RunnableWrapper.INSTANCE.wrap(task), tasks::remove, executor);
+        tasks.add(timerTask);
+        LockSupport.unpark(thread);
+        LOG.scheduledTimerTask(timerTask, delayInMillis);
+        return timerTask;
+    }
+
+    @Override
+    public void shutdown() throws InterruptedException {
+        if (running.compareAndSet(true, false)) {
+            LOG.shutdownTimer(name);
+            thread.interrupt();
+            thread.join();
+        }
+    }
+
+    private static final class Task implements TimerTask {
+        static final int STATE_NEW = 0; // was scheduled, but isn't running yet
+        static final int STATE_RUNNING = 1; // running on the executor
+        static final int STATE_FINISHED = 2; // finished running
+        static final int STATE_CANCELLED = 3; // cancelled before it could be executed
+
+        final long startTime; // in nanos, to be compared with System.nanoTime()
+        final Runnable runnable;
+        final Executor executorOverride; // may be null, which means that the timer's executor shall be used
+        final AtomicInteger state = new AtomicInteger(STATE_NEW);
+
+        private final Consumer<TimerTask> onCancel;
+
+        Task(long startTime, Runnable runnable, Consumer<TimerTask> onCancel, Executor executorOverride) {
+            this.startTime = startTime;
+            this.runnable = checkNotNull(runnable, "Runnable task must be set");
+            this.onCancel = checkNotNull(onCancel, "Cancellation callback must be set");
+            this.executorOverride = executorOverride;
+        }
+
+        @Override
+        public boolean isDone() {
+            int state = this.state.get();
+            return state == STATE_FINISHED || state == STATE_CANCELLED;
+        }
+
+        @Override
+        public boolean cancel() {
+            // can't cancel if it's already running
+            if (state.compareAndSet(STATE_NEW, STATE_CANCELLED)) {
+                LOG.cancelledTimerTask(this);
+                onCancel.accept(this);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/Timer.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/Timer.java
@@ -1,146 +1,30 @@
 package io.smallrye.faulttolerance.core.timer;
 
-import static io.smallrye.faulttolerance.core.timer.TimerLogger.LOG;
-import static io.smallrye.faulttolerance.core.util.Preconditions.checkNotNull;
-
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.SortedSet;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.LockSupport;
-
-import io.smallrye.faulttolerance.core.util.RunnableWrapper;
 
 /**
- * Allows scheduling tasks ({@code Runnable}s) to be executed on an {@code Executor} after some delay.
- * <p>
- * Starts one thread that processes submitted tasks in a loop and when it's time for a task to run,
- * it gets submitted to the executor.
+ * Timer allows scheduling tasks for execution in the future. Tasks are always executed
+ * on a well-defined {@link Executor}. Timer implementations must have a default executor
+ * for tasks scheduled using {@link #schedule(long, Runnable)}. Tasks scheduled using
+ * {@link #schedule(long, Runnable, Executor)} are executed on the given executor.
  */
-// TODO implement a hashed wheel?
-public final class Timer {
-    private static final AtomicInteger COUNTER = new AtomicInteger(0);
-
-    private static final Comparator<TimerTask> TIMER_TASK_COMPARATOR = (o1, o2) -> {
-        if (o1 == o2) {
-            // two different instances are never equal
-            return 0;
-        }
-
-        // must _not_ return 0 if start times are equal, because that isn't consistent
-        // with `equals` (see also above)
-        return o1.startTime <= o2.startTime ? -1 : 1;
-    };
-
-    private final String name;
-
-    private final SortedSet<TimerTask> tasks;
-
-    private final Thread thread;
-
-    private final AtomicBoolean running = new AtomicBoolean(true);
-
+public interface Timer {
     /**
-     * @param executor default {@link Executor} used for running scheduled tasks, unless an executor
-     *        is provided when {@link #schedule(long, Runnable, Executor) scheduling} a task
-     */
-    public Timer(Executor executor) {
-        checkNotNull(executor, "Executor must be set");
-
-        this.name = "SmallRye Fault Tolerance Timer " + COUNTER.incrementAndGet();
-        LOG.createdTimer(name);
-
-        this.tasks = new ConcurrentSkipListSet<>(TIMER_TASK_COMPARATOR);
-        this.thread = new Thread(() -> {
-            while (running.get()) {
-                try {
-                    if (tasks.isEmpty()) {
-                        LockSupport.park();
-                    } else {
-                        TimerTask task;
-                        try {
-                            task = tasks.first();
-                        } catch (NoSuchElementException e) {
-                            // can happen if all tasks are cancelled right between `tasks.isEmpty` and `tasks.first`
-                            continue;
-                        }
-
-                        long currentTime = System.nanoTime();
-                        long taskStartTime = task.startTime;
-
-                        // must _not_ use `taskStartTime <= currentTime`, because `System.nanoTime()`
-                        // is relative to an arbitrary number and so it can possibly overflow;
-                        // in such case, `taskStartTime` can be positive, `currentTime` can be negative,
-                        //  and yet `taskStartTime` is _before_ `currentTime`
-                        if (taskStartTime - currentTime <= 0) {
-                            tasks.remove(task);
-                            if (task.state.compareAndSet(TimerTask.STATE_NEW, TimerTask.STATE_RUNNING)) {
-                                Executor executorForTask = task.executorOverride;
-                                if (executorForTask == null) {
-                                    executorForTask = executor;
-                                }
-
-                                executorForTask.execute(() -> {
-                                    LOG.runningTimerTask(task);
-                                    try {
-                                        task.runnable.run();
-                                    } finally {
-                                        task.state.set(TimerTask.STATE_FINISHED);
-                                    }
-                                });
-                            }
-                        } else {
-                            // this is OK even if another timer is scheduled during the sleep (even if that timer should
-                            // fire sooner than `taskStartTime`), because `schedule` always calls` LockSupport.unpark`
-                            LockSupport.parkNanos(taskStartTime - currentTime);
-                        }
-                    }
-                } catch (Exception e) {
-                    // can happen e.g. when the executor is shut down sooner than the timer
-                    LOG.unexpectedExceptionInTimerLoop(e);
-                }
-            }
-        }, name);
-        thread.start();
-    }
-
-    /**
-     * Schedules the {@code task} to be executed in {@code delayInMillis} on the {@link Executor}
-     * specified when creating this {@code Timer}.
+     * Schedules the {@code task} to be executed in {@code delayInMillis} on this timer's
+     * default {@link Executor}.
      * <p>
      * Equivalent to {@code schedule(delayInMillis, task, null)}.
      */
-    public TimerTask schedule(long delayInMillis, Runnable task) {
-        return schedule(delayInMillis, task, null);
-    }
+    TimerTask schedule(long delayInMillis, Runnable task);
 
     /**
      * Schedules the {@code task} to be executed in {@code delayInMillis} on given {@code executor}.
-     * If {@code executor} is {@code null}, the {@link Executor} specified when creating this {@code Timer}
-     * is used.
+     * If {@code executor} is {@code null}, this timer's default executor is used.
      */
-    public TimerTask schedule(long delayInMillis, Runnable task, Executor executor) {
-        long startTime = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayInMillis);
-        TimerTask timerTask = new TimerTask(startTime, RunnableWrapper.INSTANCE.wrap(task), tasks::remove, executor);
-        tasks.add(timerTask);
-        LockSupport.unpark(thread);
-        LOG.scheduledTimerTask(timerTask, delayInMillis);
-        return timerTask;
-    }
+    TimerTask schedule(long delayInMillis, Runnable task, Executor executor);
 
     /**
-     * Should be called <i>before</i> the underlying {@code executor} is shut down.
-     * Returns only after the timer thread finishes.
+     * Shuts down this timer. Returns after all internal resources of this timer are shut down.
      */
-    public void shutdown() throws InterruptedException {
-        if (running.compareAndSet(true, false)) {
-            LOG.shutdownTimer(name);
-            thread.interrupt();
-            thread.join();
-        }
-    }
+    void shutdown() throws InterruptedException;
 }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/TimerTask.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/TimerTask.java
@@ -1,44 +1,21 @@
 package io.smallrye.faulttolerance.core.timer;
 
-import static io.smallrye.faulttolerance.core.timer.TimerLogger.LOG;
-import static io.smallrye.faulttolerance.core.util.Preconditions.checkNotNull;
+/**
+ * Result of scheduling a task on a {@link Timer}. Allows observing whether the task
+ * {@linkplain #isDone() is done} and {@linkplain #cancel() cancelling} the task.
+ */
+public interface TimerTask {
+    /**
+     * Returns whether this task is done. A task is done if it has already finished or was successfully cancelled.
+     *
+     * @return whether this task is done
+     */
+    boolean isDone();
 
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-
-public final class TimerTask {
-    static final int STATE_NEW = 0; // was scheduled, but isn't running yet
-    static final int STATE_RUNNING = 1; // running on the executor
-    static final int STATE_FINISHED = 2; // finished running
-    static final int STATE_CANCELLED = 3; // cancelled before it could be executed
-
-    final long startTime; // in nanos, to be compared with System.nanoTime()
-    final Runnable runnable;
-    final Executor executorOverride; // may be null, which means that the timer's executor shall be used
-    final AtomicInteger state = new AtomicInteger(STATE_NEW);
-
-    private final Consumer<TimerTask> onCancel;
-
-    TimerTask(long startTime, Runnable runnable, Consumer<TimerTask> onCancel, Executor executorOverride) {
-        this.startTime = startTime;
-        this.runnable = checkNotNull(runnable, "Runnable task must be set");
-        this.onCancel = checkNotNull(onCancel, "Cancellation callback must be set");
-        this.executorOverride = executorOverride;
-    }
-
-    public boolean isDone() {
-        int state = this.state.get();
-        return state == STATE_FINISHED || state == STATE_CANCELLED;
-    }
-
-    public boolean cancel() {
-        // can't cancel if it's already running
-        if (state.compareAndSet(STATE_NEW, STATE_CANCELLED)) {
-            LOG.cancelledTimerTask(this);
-            onCancel.accept(this);
-            return true;
-        }
-        return false;
-    }
+    /**
+     * Requests cancellation of this task. Task cannot be cancelled when it's already running.
+     *
+     * @return whether the task was successfully cancelled
+     */
+    boolean cancel();
 }

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/circuit/breaker/FutureCircuitBreakerTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/circuit/breaker/FutureCircuitBreakerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import io.smallrye.faulttolerance.core.InvocationContext;
 import io.smallrye.faulttolerance.core.stopwatch.TestStopwatch;
+import io.smallrye.faulttolerance.core.timer.TestTimer;
 import io.smallrye.faulttolerance.core.util.SetBasedExceptionDecision;
 import io.smallrye.faulttolerance.core.util.SetOfThrowables;
 import io.smallrye.faulttolerance.core.util.TestException;
@@ -31,9 +32,10 @@ public class FutureCircuitBreakerTest {
     public void test1() throws Exception {
         CircuitBreaker<Future<String>> cb = new CircuitBreaker<>(invocation(), "test invocation",
                 new SetBasedExceptionDecision(testException, SetOfThrowables.EMPTY, false),
-                1000, 4, 0.5, 2, stopwatch);
+                1000, 4, 0.5, 2, stopwatch, new TestTimer());
 
         // circuit breaker is closed
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_CLOSED);
         assertThat(cb.apply(new InvocationContext<>(() -> completedFuture("foobar1"))).get()).isEqualTo("foobar1");
         assertThat(cb.apply(new InvocationContext<>(() -> completedFuture("foobar2"))).get()).isEqualTo("foobar2");
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(() -> {
@@ -48,6 +50,7 @@ public class FutureCircuitBreakerTest {
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(TestException::doThrow)))
                 .isExactlyInstanceOf(TestException.class);
         // circuit breaker is open
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_OPEN);
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(() -> completedFuture("ignored"))))
                 .isExactlyInstanceOf(CircuitBreakerOpenException.class);
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(() -> completedFuture("ignored"))))
@@ -61,11 +64,12 @@ public class FutureCircuitBreakerTest {
         stopwatch.setCurrentValue(1500);
         Future<String> foobar7 = cb.apply(new InvocationContext<>(() -> completedFuture("foobar7")));
         assertThat(foobar7.get()).isEqualTo("foobar7");
-
         // circuit breaker is half-open
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_HALF_OPEN);
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(TestException::doThrow)))
                 .isExactlyInstanceOf(TestException.class);
         // circuit breaker is open
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_OPEN);
         stopwatch.setCurrentValue(0);
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(() -> completedFuture("ignored"))))
                 .isExactlyInstanceOf(CircuitBreakerOpenException.class);
@@ -77,9 +81,11 @@ public class FutureCircuitBreakerTest {
         Future<String> foobar8 = cb.apply(new InvocationContext<>(() -> completedFuture("foobar8")));
         assertThat(foobar8.get()).isEqualTo("foobar8");
         // circuit breaker is half-open
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_HALF_OPEN);
         Future<String> foobar9 = cb.apply(new InvocationContext<>(() -> completedFuture("foobar9")));
         assertThat(foobar9.get()).isEqualTo("foobar9");
         // circuit breaker is closed
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_CLOSED);
         Future<String> foobar10 = cb.apply(new InvocationContext<>(() -> completedFuture("foobar10")));
         assertThat(foobar10.get()).isEqualTo("foobar10");
     }
@@ -88,9 +94,10 @@ public class FutureCircuitBreakerTest {
     public void test2() throws Exception {
         CircuitBreaker<Future<String>> cb = new CircuitBreaker<>(invocation(), "test invocation",
                 new SetBasedExceptionDecision(testException, SetOfThrowables.EMPTY, false),
-                1000, 4, 0.5, 2, stopwatch);
+                1000, 4, 0.5, 2, stopwatch, new TestTimer());
 
         // circuit breaker is closed
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_CLOSED);
         Future<String> foobar1 = cb.apply(new InvocationContext<>(() -> completedFuture("foobar1")));
         assertThat(foobar1.get()).isEqualTo("foobar1");
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(TestException::doThrow)))
@@ -100,6 +107,7 @@ public class FutureCircuitBreakerTest {
         Future<String> foobar2 = cb.apply(new InvocationContext<>(() -> completedFuture("foobar2")));
         assertThat(foobar2.get()).isEqualTo("foobar2");
         // circuit breaker is open
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_OPEN);
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(() -> completedFuture("ignored"))))
                 .isExactlyInstanceOf(CircuitBreakerOpenException.class);
         assertThatThrownBy(() -> cb.apply(new InvocationContext<>(() -> completedFuture("ignored"))))
@@ -113,8 +121,42 @@ public class FutureCircuitBreakerTest {
         stopwatch.setCurrentValue(1500);
         assertThat(cb.apply(new InvocationContext<>(() -> completedFuture("foobar3"))).get()).isEqualTo("foobar3");
         // circuit breaker is half-open
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_HALF_OPEN);
         assertThat(cb.apply(new InvocationContext<>(() -> completedFuture("foobar4"))).get()).isEqualTo("foobar4");
         // circuit breaker is closed
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_CLOSED);
+        assertThat(cb.apply(new InvocationContext<>(() -> completedFuture("foobar5"))).get()).isEqualTo("foobar5");
+    }
+
+    @Test
+    public void test3() throws Exception {
+        TestTimer timer = new TestTimer();
+        CircuitBreaker<Future<String>> cb = new CircuitBreaker<>(invocation(), "test invocation",
+                new SetBasedExceptionDecision(testException, SetOfThrowables.EMPTY, false),
+                1000, 4, 0.5, 2, stopwatch, timer);
+
+        assertThat(timer.hasScheduledTasks()).isFalse();
+
+        // circuit breaker is closed
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_CLOSED);
+        Future<String> foobar1 = cb.apply(new InvocationContext<>(() -> completedFuture("foobar1")));
+        assertThat(foobar1.get()).isEqualTo("foobar1");
+        assertThatThrownBy(() -> cb.apply(new InvocationContext<>(TestException::doThrow)))
+                .isExactlyInstanceOf(TestException.class);
+        assertThatThrownBy(() -> cb.apply(new InvocationContext<>(TestException::doThrow)))
+                .isExactlyInstanceOf(TestException.class);
+        Future<String> foobar2 = cb.apply(new InvocationContext<>(() -> completedFuture("foobar2")));
+        assertThat(foobar2.get()).isEqualTo("foobar2");
+        // circuit breaker is open
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_OPEN);
+        assertThat(timer.hasScheduledTasks()).isTrue();
+        timer.executeSynchronously(timer.nextScheduledTask());
+        // circuit breaker is half-open
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_HALF_OPEN);
+        assertThat(cb.apply(new InvocationContext<>(() -> completedFuture("foobar3"))).get()).isEqualTo("foobar3");
+        assertThat(cb.apply(new InvocationContext<>(() -> completedFuture("foobar4"))).get()).isEqualTo("foobar4");
+        // circuit breaker is closed
+        assertThat(cb.currentState()).isEqualTo(CircuitBreaker.STATE_CLOSED);
         assertThat(cb.apply(new InvocationContext<>(() -> completedFuture("foobar5"))).get()).isEqualTo("foobar5");
     }
 }

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/composition/Strategies.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/composition/Strategies.java
@@ -6,6 +6,7 @@ import io.smallrye.faulttolerance.core.fallback.Fallback;
 import io.smallrye.faulttolerance.core.retry.Retry;
 import io.smallrye.faulttolerance.core.retry.SyncDelay;
 import io.smallrye.faulttolerance.core.stopwatch.TestStopwatch;
+import io.smallrye.faulttolerance.core.timer.TestTimer;
 import io.smallrye.faulttolerance.core.util.ExceptionDecision;
 
 /**
@@ -30,6 +31,6 @@ final class Strategies {
 
     static <V> CircuitBreaker<V> circuitBreaker(FaultToleranceStrategy<V> delegate, int delayInMillis) {
         return new CircuitBreaker<>(delegate, "circuit breaker", ExceptionDecision.ALWAYS_FAILURE,
-                delayInMillis, 5, 0.2, 3, new TestStopwatch());
+                delayInMillis, 5, 0.2, 3, new TestStopwatch(), new TestTimer());
     }
 }

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/RealWorldCompletionStageTimeoutTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/RealWorldCompletionStageTimeoutTest.java
@@ -25,6 +25,7 @@ import io.smallrye.faulttolerance.core.async.CompletionStageExecution;
 import io.smallrye.faulttolerance.core.stopwatch.RunningStopwatch;
 import io.smallrye.faulttolerance.core.stopwatch.Stopwatch;
 import io.smallrye.faulttolerance.core.stopwatch.SystemStopwatch;
+import io.smallrye.faulttolerance.core.timer.ThreadTimer;
 import io.smallrye.faulttolerance.core.timer.Timer;
 import io.smallrye.faulttolerance.core.util.TestException;
 
@@ -54,7 +55,7 @@ public class RealWorldCompletionStageTimeoutTest {
         executor = Executors.newSingleThreadExecutor();
 
         timerExecutor = Executors.newSingleThreadExecutor();
-        timer = new Timer(timerExecutor);
+        timer = new ThreadTimer(timerExecutor);
         timerWatcher = new TimerTimeoutWatcher(timer);
     }
 

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/TimerTimeoutWatcherTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/TimerTimeoutWatcherTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import io.smallrye.faulttolerance.core.timer.ThreadTimer;
 import io.smallrye.faulttolerance.core.timer.Timer;
 
 @EnabledOnOs(OS.LINUX)
@@ -26,7 +27,7 @@ public class TimerTimeoutWatcherTest {
     @BeforeEach
     public void setUp() {
         executor = Executors.newSingleThreadExecutor();
-        timer = new Timer(executor);
+        timer = new ThreadTimer(executor);
         watcher = new TimerTimeoutWatcher(timer);
     }
 

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/TestTimer.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/TestTimer.java
@@ -1,0 +1,59 @@
+package io.smallrye.faulttolerance.core.timer;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+
+public class TestTimer implements Timer {
+    private final Queue<Task> tasks = new ConcurrentLinkedQueue<>();
+
+    @Override
+    public TimerTask schedule(long delayInMillis, Runnable runnable) {
+        Task task = new Task(runnable);
+        tasks.add(task);
+        return task;
+    }
+
+    @Override
+    public TimerTask schedule(long delayInMillis, Runnable runnable, Executor executor) {
+        Task task = new Task(runnable);
+        tasks.add(task);
+        return task;
+    }
+
+    public boolean hasScheduledTasks() {
+        return !tasks.isEmpty();
+    }
+
+    public TimerTask nextScheduledTask() {
+        return tasks.peek();
+    }
+
+    public void executeSynchronously(TimerTask task) {
+        if (tasks.remove(task)) {
+            ((Task) task).runnable.run();
+        }
+    }
+
+    @Override
+    public void shutdown() throws InterruptedException {
+    }
+
+    private class Task implements TimerTask {
+        private final Runnable runnable;
+
+        private Task(Runnable runnable) {
+            this.runnable = runnable;
+        }
+
+        @Override
+        public boolean isDone() {
+            return tasks.contains(this);
+        }
+
+        @Override
+        public boolean cancel() {
+            return tasks.remove(this);
+        }
+    }
+}

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/ThreadTimerStressTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/ThreadTimerStressTest.java
@@ -1,4 +1,4 @@
-package io.smallrye.faulttolerance.core.util;
+package io.smallrye.faulttolerance.core.timer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.byLessThan;
@@ -16,11 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import io.smallrye.faulttolerance.core.timer.Timer;
 import io.smallrye.faulttolerance.core.util.party.Party;
 
 @EnabledOnOs(OS.LINUX)
-public class TimerStressTest {
+public class ThreadTimerStressTest {
     private static final int ITERATIONS = 100;
     private static final int TASKS_PER_ITERATION = 100;
     private static final long DELAY_INCREMENT = 50;
@@ -34,7 +33,7 @@ public class TimerStressTest {
     @BeforeEach
     public void setUp() throws InterruptedException {
         executor = Executors.newFixedThreadPool(POOL_SIZE);
-        timer = new Timer(executor);
+        timer = new ThreadTimer(executor);
 
         // precreate all threads in the pool
         // if we didn't do this, the first few iterations would be dominated

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/ThreadTimerTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/ThreadTimerTest.java
@@ -1,4 +1,4 @@
-package io.smallrye.faulttolerance.core.util;
+package io.smallrye.faulttolerance.core.timer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,17 +14,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import io.smallrye.faulttolerance.core.timer.Timer;
-
 @EnabledOnOs(OS.LINUX)
-public class TimerTest {
+public class ThreadTimerTest {
     private ExecutorService executor;
     private Timer timer;
 
     @BeforeEach
     public void setUp() {
         executor = Executors.newSingleThreadExecutor();
-        timer = new Timer(executor);
+        timer = new ThreadTimer(executor);
     }
 
     @AfterEach

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/ExecutorHolder.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/ExecutorHolder.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import io.smallrye.faulttolerance.core.event.loop.EventLoop;
+import io.smallrye.faulttolerance.core.timer.ThreadTimer;
 import io.smallrye.faulttolerance.core.timer.Timer;
 
 @Singleton
@@ -24,7 +25,7 @@ public class ExecutorHolder {
     public ExecutorHolder(AsyncExecutorProvider asyncExecutorProvider) {
         this.asyncExecutor = asyncExecutorProvider.get();
         this.eventLoop = EventLoop.get();
-        this.timer = new Timer(asyncExecutor);
+        this.timer = new ThreadTimer(asyncExecutor);
         this.shouldShutdownAsyncExecutor = asyncExecutorProvider instanceof DefaultAsyncExecutorProvider;
     }
 

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceInterceptor.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceInterceptor.java
@@ -323,7 +323,8 @@ public class FaultToleranceInterceptor {
                     operation.getCircuitBreaker().requestVolumeThreshold(),
                     operation.getCircuitBreaker().failureRatio(),
                     operation.getCircuitBreaker().successThreshold(),
-                    SystemStopwatch.INSTANCE);
+                    SystemStopwatch.INSTANCE,
+                    timer);
 
             String cbName = operation.hasCircuitBreakerName()
                     ? operation.getCircuitBreakerName().value()
@@ -393,7 +394,8 @@ public class FaultToleranceInterceptor {
                     operation.getCircuitBreaker().requestVolumeThreshold(),
                     operation.getCircuitBreaker().failureRatio(),
                     operation.getCircuitBreaker().successThreshold(),
-                    SystemStopwatch.INSTANCE);
+                    SystemStopwatch.INSTANCE,
+                    timer);
 
             String cbName = operation.hasCircuitBreakerName()
                     ? operation.getCircuitBreakerName().value()
@@ -465,7 +467,8 @@ public class FaultToleranceInterceptor {
                     operation.getCircuitBreaker().requestVolumeThreshold(),
                     operation.getCircuitBreaker().failureRatio(),
                     operation.getCircuitBreaker().successThreshold(),
-                    SystemStopwatch.INSTANCE);
+                    SystemStopwatch.INSTANCE,
+                    timer);
 
             String cbName = operation.hasCircuitBreakerName()
                     ? operation.getCircuitBreakerName().value()

--- a/implementation/standalone/src/main/java/io/smallrye/faulttolerance/standalone/StandaloneFaultToleranceSpi.java
+++ b/implementation/standalone/src/main/java/io/smallrye/faulttolerance/standalone/StandaloneFaultToleranceSpi.java
@@ -12,6 +12,7 @@ import io.smallrye.faulttolerance.core.apiimpl.BuilderEagerDependencies;
 import io.smallrye.faulttolerance.core.apiimpl.BuilderLazyDependencies;
 import io.smallrye.faulttolerance.core.apiimpl.FaultToleranceImpl;
 import io.smallrye.faulttolerance.core.event.loop.EventLoop;
+import io.smallrye.faulttolerance.core.timer.ThreadTimer;
 import io.smallrye.faulttolerance.core.timer.Timer;
 
 public class StandaloneFaultToleranceSpi implements FaultToleranceSpi {
@@ -30,7 +31,7 @@ public class StandaloneFaultToleranceSpi implements FaultToleranceSpi {
         // TODO let users integrate their own thread pool
         final ExecutorService executor = Executors.newCachedThreadPool();
         final EventLoop eventLoop = EventLoop.get();
-        final Timer timer = new Timer(executor);
+        final Timer timer = new ThreadTimer(executor);
 
         @Override
         public boolean ftEnabled() {

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/timer/halfopen/AsyncHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/timer/halfopen/AsyncHelloService.java
@@ -1,0 +1,30 @@
+package io.smallrye.faulttolerance.async.compstage.circuit.breaker.timer.halfopen;
+
+import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
+import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+
+@ApplicationScoped
+public class AsyncHelloService {
+    static final int ROLLING_WINDOW = 10;
+    static final int DELAY = 200;
+
+    @Asynchronous
+    @CircuitBreaker(requestVolumeThreshold = ROLLING_WINDOW, delay = DELAY)
+    @CircuitBreakerName("hello")
+    public CompletionStage<String> hello(boolean fail) {
+        if (fail) {
+            return failedStage(new IllegalArgumentException());
+        }
+
+        return completedStage("Hello, world!");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/timer/halfopen/CompletionStageCircuitBreakerTimerHalfOpenTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/timer/halfopen/CompletionStageCircuitBreakerTimerHalfOpenTest.java
@@ -1,0 +1,54 @@
+package io.smallrye.faulttolerance.async.compstage.circuit.breaker.timer.halfopen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.api.CircuitBreakerMaintenance;
+import io.smallrye.faulttolerance.api.CircuitBreakerState;
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class CompletionStageCircuitBreakerTimerHalfOpenTest {
+    @Inject
+    private AsyncHelloService service;
+
+    @Inject
+    private CircuitBreakerMaintenance cb;
+
+    @Test
+    public void circuitBreakerMovesToHalfOpenWithoutInvocations() throws InterruptedException, ExecutionException {
+        AtomicInteger stateChanges = new AtomicInteger(0);
+        cb.onStateChange("hello", ignored -> stateChanges.incrementAndGet());
+
+        // closed
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.CLOSED);
+
+        for (int i = 0; i < AsyncHelloService.ROLLING_WINDOW; i++) {
+            assertThatThrownBy(() -> service.hello(true).toCompletableFuture().get())
+                    .isExactlyInstanceOf(ExecutionException.class)
+                    .hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+        }
+
+        // open
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.OPEN);
+
+        Thread.sleep(AsyncHelloService.DELAY * 3);
+
+        // half-open
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.HALF_OPEN);
+
+        assertThat(service.hello(false).toCompletableFuture().get()).isEqualTo("Hello, world!");
+
+        // closed
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.CLOSED);
+
+        assertThat(stateChanges).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/timer/halfopen/CircuitBreakerTimerHalfOpenTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/timer/halfopen/CircuitBreakerTimerHalfOpenTest.java
@@ -1,0 +1,52 @@
+package io.smallrye.faulttolerance.circuitbreaker.timer.halfopen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.api.CircuitBreakerMaintenance;
+import io.smallrye.faulttolerance.api.CircuitBreakerState;
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class CircuitBreakerTimerHalfOpenTest {
+    @Inject
+    private HelloService service;
+
+    @Inject
+    private CircuitBreakerMaintenance cb;
+
+    @Test
+    public void circuitBreakerMovesToHalfOpenWithoutInvocations() throws InterruptedException {
+        AtomicInteger stateChanges = new AtomicInteger(0);
+        cb.onStateChange("hello", ignored -> stateChanges.incrementAndGet());
+
+        // closed
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.CLOSED);
+
+        for (int i = 0; i < HelloService.ROLLING_WINDOW; i++) {
+            assertThatThrownBy(() -> service.hello(true))
+                    .isExactlyInstanceOf(IllegalArgumentException.class);
+        }
+
+        // open
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.OPEN);
+
+        Thread.sleep(HelloService.DELAY * 3);
+
+        // half-open
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.HALF_OPEN);
+
+        assertThat(service.hello(false)).isEqualTo("Hello, world!");
+
+        // closed
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.CLOSED);
+
+        assertThat(stateChanges).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/timer/halfopen/HelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/circuitbreaker/timer/halfopen/HelloService.java
@@ -1,0 +1,23 @@
+package io.smallrye.faulttolerance.circuitbreaker.timer.halfopen;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+
+@ApplicationScoped
+public class HelloService {
+    static final int ROLLING_WINDOW = 10;
+    static final int DELAY = 200;
+
+    @CircuitBreaker(requestVolumeThreshold = ROLLING_WINDOW, delay = DELAY)
+    @CircuitBreakerName("hello")
+    public String hello(boolean fail) throws InterruptedException {
+        if (fail) {
+            throw new IllegalArgumentException();
+        }
+
+        return "Hello, world!";
+    }
+}


### PR DESCRIPTION
The circuit breaker implementation used to perform state transitions only during invocations (that is, synchronously). This is easy to implement and doesn't affect correctness of the circuit breaker algorithm, so there's nothing wrong with it.

However, SmallRye Fault Tolerance allows external observation of the circuit breaker state. With the existing implementation of state transitions only during invocations, such external observations would be correct when moving from closed to open and from half-open to closed (because these transitions are defined to happen as a result of an invocation), but would _not_ be correct when moving from open to half-open (which is defined to happen after certain amount of time, regardless of invocations).

For example, if the circuit breaker is configured to transition from open to half-open after 5 seconds, but there are no invocations for 10 seconds, then external observers will see the circuit breaker staying open for twice the time it should be.

With this commit, the synchronous transition from open to half-open is accompanied by an asynchronous, timer-based transition. This makes sure that even if there are no invocations, the circuit breaker will move from open to half-open correctly.

The actual state transition is atomic CAS, so it doesn't matter that there are two threads trying to make the same transition at roughly the same time. Only one of them succeeds, and that will also emit the state transition event.

Fixes #249