### PR TITLE
reorder reference guides

### DIFF
--- a/doc/modules/ROOT/pages/reference/asynchronous.adoc
+++ b/doc/modules/ROOT/pages/reference/asynchronous.adoc
@@ -82,18 +82,6 @@ They are still supported, but at some point, {smallrye-fault-tolerance} will sto
 
 We also recommend avoiding `@Asynchronous` methods that return `Future`, because the only way to obtain the future value is blocking.
 
-[[configuration]]
-== Configuration
-
-There is no configuration for `@Asynchronous` or `@AsynchronousNonBlocking`.
-
-[[metrics]]
-== Metrics
-
-Asynchronous execution does not emit any metrics.
-
-See xref:reference/metrics.adoc[the Metrics reference guide] for general metrics information.
-
 [[interactions]]
 == Interactions with Other Strategies
 
@@ -113,6 +101,18 @@ If the execution has to wait in the bulkhead queue, it may later end up on a dif
 
 If the original thread is an event loop thread and event loop integration is enabled, then the event loop is always used to execute the guarded method.
 In such case, all retry attempts and queued bulkhead executions are guaranteed to happen on the original thread.
+
+[[configuration]]
+== Configuration
+
+There is no configuration for `@Asynchronous` or `@AsynchronousNonBlocking`.
+
+[[metrics]]
+== Metrics
+
+Asynchronous execution does not emit any metrics.
+
+See xref:reference/metrics.adoc[the Metrics reference guide] for general metrics information.
 
 == Extra Features
 

--- a/doc/modules/ROOT/pages/reference/bulkhead.adoc
+++ b/doc/modules/ROOT/pages/reference/bulkhead.adoc
@@ -19,6 +19,23 @@ More specifically, the bulkhead state is uniquely identified by the combination 
 
 For example, if there’s a guarded method `doWork` on a bean which is `@RequestScoped`, each request will have its own instance of the bean, but all invocations of `doWork` will share the same bulkhead state.
 
+[[interactions]]
+== Interactions with Other Strategies
+
+See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
+
+If `@Fallback` is used with `@Bulkhead`, the fallback method or handler may be invoked if a `BulkheadException` is thrown, depending on the fallback configuration.
+
+If `@Retry` is used with `@Bulkhead`, each retry attempt is processed by the bulkhead as an independent invocation.
+If `BulkheadException` is thrown, the execution may be retried, depending on how retry is configured.
+
+If `@CircuitBreaker` is used with `@Bulkhead`, the circuit breaker is checked before enforcing the concurrency limit.
+If concurrency limiting results in `BulkheadException`, this may be counted as a failure, depending on how the circuit breaker is configured.
+
+If `@RateLimit` is used with `@Bulkhead`, the rate limit is enforced before enforcing the concurrency limit.
+
+If `@Timeout` is used with `@Bulkhead`, the timeout watcher is started before enforcing the concurrency limit.
+
 [[configuration]]
 == Configuration
 
@@ -101,20 +118,3 @@ a| * `method` - the fully qualified method name
 |===
 
 See xref:reference/metrics.adoc[the Metrics reference guide] for general metrics information.
-
-[[interactions]]
-== Interactions with Other Strategies
-
-See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
-
-If `@Fallback` is used with `@Bulkhead`, the fallback method or handler may be invoked if a `BulkheadException` is thrown, depending on the fallback configuration.
-
-If `@Retry` is used with `@Bulkhead`, each retry attempt is processed by the bulkhead as an independent invocation.
-If `BulkheadException` is thrown, the execution may be retried, depending on how retry is configured.
-
-If `@CircuitBreaker` is used with `@Bulkhead`, the circuit breaker is checked before enforcing the concurrency limit.
-If concurrency limiting results in `BulkheadException`, this may be counted as a failure, depending on how the circuit breaker is configured.
-
-If `@RateLimit` is used with `@Bulkhead`, the rate limit is enforced before enforcing the concurrency limit.
-
-If `@Timeout` is used with `@Bulkhead`, the timeout watcher is started before enforcing the concurrency limit.

--- a/doc/modules/ROOT/pages/reference/circuit-breaker.adoc
+++ b/doc/modules/ROOT/pages/reference/circuit-breaker.adoc
@@ -55,6 +55,16 @@ More specifically, the circuit breaker state is uniquely identified by the combi
 
 For example, if there’s a guarded method `doWork` on a bean which is `@RequestScoped`, each request will have its own instance of the bean, but all invocations of `doWork` will share the same circuit breaker state.
 
+[[interactions]]
+== Interactions with Other Strategies
+
+See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
+
+If `@Fallback` is used with `@CircuitBreaker`, the fallback method or handler may be invoked if a `CircuitBreakerOpenException` is thrown, depending on the fallback configuration.
+
+If `@Retry` is used with `@RateLimit`, each retry attempt is processed by the circuit breaker as an independent invocation.
+If `CircuitBreakerOpenException` is thrown, the execution may be retried, depending on how retry is configured.
+
 [[configuration]]
 == Configuration
 
@@ -168,16 +178,6 @@ a| * `method` - the fully qualified method name
 |===
 
 See xref:reference/metrics.adoc[the Metrics reference guide] for general metrics information.
-
-[[interactions]]
-== Interactions with Other Strategies
-
-See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
-
-If `@Fallback` is used with `@CircuitBreaker`, the fallback method or handler may be invoked if a `CircuitBreakerOpenException` is thrown, depending on the fallback configuration.
-
-If `@Retry` is used with `@RateLimit`, each retry attempt is processed by the circuit breaker as an independent invocation.
-If `CircuitBreakerOpenException` is thrown, the execution may be retried, depending on how retry is configured.
 
 == Extra Features
 

--- a/doc/modules/ROOT/pages/reference/fallback.adoc
+++ b/doc/modules/ROOT/pages/reference/fallback.adoc
@@ -14,6 +14,13 @@ More specifically:
 . Otherwise, if the guarded method throws an exception whose type is assignable to any of the `applyOn` types (see <<apply-on,applyOn>>), the fallback value is obtained and returned.
 . Otherwise, the exception is rethrown.
 
+[[interactions]]
+== Interactions with Other Strategies
+
+See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
+
+If `@Fallback` is used, the fallback method or handler may be invoked if other fault tolerance strategies throw an exception, depending on the fallback configuration.
+
 [[configuration]]
 == Configuration
 
@@ -74,13 +81,6 @@ Fallback does not emit any metrics on its own.
 
 See xref:reference/metrics.adoc[the Metrics reference guide] for general metrics information.
 Fallback is included in the overall method invocation metric described there.
-
-[[interactions]]
-== Interactions with Other Strategies
-
-See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
-
-If `@Fallback` is used, the fallback method or handler may be invoked if other fault tolerance strategies throw an exception, depending on the fallback configuration.
 
 == Extra Features
 

--- a/doc/modules/ROOT/pages/reference/rate-limit.adoc
+++ b/doc/modules/ROOT/pages/reference/rate-limit.adoc
@@ -39,6 +39,19 @@ More specifically, the rate limit state is uniquely identified by the combinatio
 
 For example, if there’s a guarded method `doWork` on a bean which is `@RequestScoped`, each request will have its own instance of the bean, but all invocations of `doWork` will share the same rate limit state.
 
+[[interactions]]
+== Interactions with Other Strategies
+
+See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
+
+If `@Fallback` is used with `@RateLimit`, the fallback method or handler may be invoked if a `RateLimitException` is thrown, depending on the fallback configuration.
+
+If `@Retry` is used with `@RateLimit`, each retry attempt is processed by the rate limit as an independent invocation.
+If `RateLimitException` is thrown, the execution may be retried, depending on how retry is configured.
+
+If `@CircuitBreaker` is used with `@RateLimit`, the circuit breaker is checked before enforcing the rate limit.
+If rate limiting results in `RateLimitException`, this may be counted as a failure, depending on how the circuit breaker is configured.
+
 [[configuration]]
 == Configuration
 
@@ -121,16 +134,3 @@ a| * `method` - the fully qualified method name
 |===
 
 See xref:reference/metrics.adoc[the Metrics reference guide] for general metrics information.
-
-[[interactions]]
-== Interactions with Other Strategies
-
-See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
-
-If `@Fallback` is used with `@RateLimit`, the fallback method or handler may be invoked if a `RateLimitException` is thrown, depending on the fallback configuration.
-
-If `@Retry` is used with `@RateLimit`, each retry attempt is processed by the rate limit as an independent invocation.
-If `RateLimitException` is thrown, the execution may be retried, depending on how retry is configured.
-
-If `@CircuitBreaker` is used with `@RateLimit`, the circuit breaker is checked before enforcing the rate limit.
-If rate limiting results in `RateLimitException`, this may be counted as a failure, depending on how the circuit breaker is configured.

--- a/doc/modules/ROOT/pages/reference/retry.adoc
+++ b/doc/modules/ROOT/pages/reference/retry.adoc
@@ -13,6 +13,13 @@ More specifically:
 . Otherwise, if the guarded method throws an exception whose type is assignable to any of the `retryOn` types (see <<retry-on,retryOn>>), the method call is retried.
 . Otherwise, the exception is rethrown.
 
+[[interactions]]
+== Interactions with Other Strategies
+
+See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
+
+If `@Fallback` is used with `@Retry`, the fallback method or handler may be invoked if all retry attempts failed, depending on the fallback configuration.
+
 [[configuration]]
 == Configuration
 
@@ -113,13 +120,6 @@ a| * `method` - the fully qualified method name
 |===
 
 See xref:reference/metrics.adoc[the Metrics reference guide] for general metrics information.
-
-[[interactions]]
-== Interactions with Other Strategies
-
-See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
-
-If `@Fallback` is used with `@Retry`, the fallback method or handler may be invoked if all retry attempts failed, depending on the fallback configuration.
 
 == Extra Features
 

--- a/doc/modules/ROOT/pages/reference/timeout.adoc
+++ b/doc/modules/ROOT/pages/reference/timeout.adoc
@@ -10,6 +10,21 @@ If the gaurded method is not `@Asynchronous` or `@AsynchronousNonBlocking`, the 
 Note that interruption requires cooperation from the executing code.
 In other words, it is not guaranteed that interrupting the method will actually make it stop.
 
+[[interactions]]
+== Interactions with Other Strategies
+
+See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
+
+If `@Fallback` is used with `@Timeout`, the fallback method or handler may be invoked if a `TimeoutException` is thrown, depending on the fallback configuration.
+
+If `@Retry` is used with `@Timeout`, each retry attempt is processed by the timeout as an independent invocation.
+If `TimeoutException` is thrown, the execution may be retried, depending on how retry is configured.
+
+If `@CircuitBreaker` is used with `@Timeout`, the circuit breaker is checked before enforcing the timeout.
+If enforcing the timeout results in `TimeoutException`, this may be counted as a failure, depending on how the circuit breaker is configured.
+
+If `@RateLimit` is used with `@Timeout`, the rate limit is enforced before enforcing the timeout.
+
 [[configuration]]
 == Configuration
 
@@ -50,18 +65,3 @@ a| * `method` - the fully qualified method name
 |===
 
 See xref:reference/metrics.adoc[the Metrics reference guide] for general metrics information.
-
-[[interactions]]
-== Interactions with Other Strategies
-
-See xref:howto/multiple.adoc[How to Use Multiple Strategies] for an overview of how fault tolerance strategies are nested.
-
-If `@Fallback` is used with `@Timeout`, the fallback method or handler may be invoked if a `TimeoutException` is thrown, depending on the fallback configuration.
-
-If `@Retry` is used with `@Timeout`, each retry attempt is processed by the timeout as an independent invocation.
-If `TimeoutException` is thrown, the execution may be retried, depending on how retry is configured.
-
-If `@CircuitBreaker` is used with `@Timeout`, the circuit breaker is checked before enforcing the timeout.
-If enforcing the timeout results in `TimeoutException`, this may be counted as a failure, depending on how the circuit breaker is configured.
-
-If `@RateLimit` is used with `@Timeout`, the rate limit is enforced before enforcing the timeout.


### PR DESCRIPTION
This commit puts the _Interactions with Other Strategies_ sections right after the _Description_ sections in all reference guides for fault tolerance strategies.

Related to #823