### PR TITLE
fix searching for fallback methods

### DIFF
--- a/implementation/autoconfig/core/src/main/java/io/smallrye/faulttolerance/autoconfig/KotlinSupport.java
+++ b/implementation/autoconfig/core/src/main/java/io/smallrye/faulttolerance/autoconfig/KotlinSupport.java
@@ -2,9 +2,11 @@ package io.smallrye.faulttolerance.autoconfig;
 
 // TODO this would ideally live in the `kotlin` module
 final class KotlinSupport {
+    private static final String KOTLIN_CONTINUATION = "kotlin.coroutines.Continuation";
+
     static boolean isLegitimate(MethodDescriptor method) {
         if (method.parameterTypes.length > 0
-                && method.parameterTypes[method.parameterTypes.length - 1].getName().equals("kotlin.coroutines.Continuation")
+                && method.parameterTypes[method.parameterTypes.length - 1].getName().equals(KOTLIN_CONTINUATION)
                 && method.name.endsWith("$suspendImpl")) {
             return false;
         }

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/KotlinSupport.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/KotlinSupport.java
@@ -7,9 +7,11 @@ import java.lang.reflect.WildcardType;
 
 // TODO this would ideally live in the `kotlin` module
 final class KotlinSupport {
+    private static final String KOTLIN_CONTINUATION = "kotlin.coroutines.Continuation";
+
     static boolean isSuspendingFunction(Method method) {
         int params = method.getParameterCount();
-        return params > 0 && method.getParameterTypes()[params - 1].getName().equals("kotlin.coroutines.Continuation");
+        return params > 0 && method.getParameterTypes()[params - 1].getName().equals(KOTLIN_CONTINUATION);
     }
 
     static Type getSuspendingFunctionResultType(Method method) {

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/internal/FallbackMethod.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/internal/FallbackMethod.java
@@ -1,0 +1,72 @@
+package io.smallrye.faulttolerance.internal;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import jakarta.interceptor.InvocationContext;
+
+import io.smallrye.faulttolerance.core.fallback.FallbackContext;
+import io.smallrye.faulttolerance.core.invocation.Invoker;
+import io.smallrye.faulttolerance.core.invocation.NormalMethodInvoker;
+import io.smallrye.faulttolerance.core.invocation.SpecialMethodInvoker;
+
+public final class FallbackMethod {
+    private static final Object[] EMPTY_ARRAY = {};
+
+    private final int exceptionParameterPosition; // < 0 if no exception parameter exists
+    private final Method method;
+
+    static FallbackMethod withoutExceptionParameter(Method method) {
+        return method == null ? null : new FallbackMethod(method, -1);
+    }
+
+    static FallbackMethod withExceptionParameter(Method method, int exceptionParameterPosition) {
+        return method == null ? null : new FallbackMethod(method, exceptionParameterPosition);
+    }
+
+    private FallbackMethod(Method method, int exceptionParameterPosition) {
+        this.method = method;
+        this.exceptionParameterPosition = exceptionParameterPosition;
+    }
+
+    // ---
+
+    public Invoker<?> createInvoker(FallbackContext<?> ctx) throws ReflectiveOperationException {
+        InvocationContext interceptionContext = ctx.invocationContext.get(InvocationContext.class);
+        Object[] arguments = interceptionContext.getParameters();
+        if (arguments == null) {
+            arguments = EMPTY_ARRAY;
+        }
+        arguments = adjustArguments(arguments, ctx.failure);
+
+        return method.isDefault()
+                ? new SpecialMethodInvoker<>(method, interceptionContext.getTarget(), arguments)
+                : new NormalMethodInvoker<>(method, interceptionContext.getTarget(), arguments);
+    }
+
+    private Object[] adjustArguments(Object[] arguments, Throwable exception) {
+        if (method.getParameterCount() == arguments.length) {
+            return arguments;
+        }
+
+        if (method.getParameterCount() == arguments.length + 1) {
+            Object[] argumentsWithException = new Object[arguments.length + 1];
+
+            int exceptionParameterPosition = this.exceptionParameterPosition;
+            for (int i = 0; i < arguments.length + 1; i++) {
+                if (i < exceptionParameterPosition) {
+                    argumentsWithException[i] = arguments[i];
+                } else if (i == exceptionParameterPosition) {
+                    argumentsWithException[i] = exception;
+                } else { // i > exceptionParameterPosition
+                    argumentsWithException[i] = arguments[i - 1];
+                }
+            }
+
+            return argumentsWithException;
+        }
+
+        throw new IllegalArgumentException("Cannot adjust arguments " + Arrays.toString(arguments)
+                + " to fallback method " + method);
+    }
+}

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/internal/KotlinSupport.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/internal/KotlinSupport.java
@@ -1,0 +1,25 @@
+package io.smallrye.faulttolerance.internal;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+// TODO this would ideally live in the `kotlin` module
+final class KotlinSupport {
+    private static final String KOTLIN_CONTINUATION = "kotlin.coroutines.Continuation";
+
+    static boolean isSuspendingFunction(Method method) {
+        int params = method.getParameterCount();
+        return params > 0 && method.getParameterTypes()[params - 1].getName().equals(KOTLIN_CONTINUATION);
+    }
+
+    static boolean isSuspendingFunction(Type[] parameterTypes) {
+        int params = parameterTypes.length;
+        if (params > 0) {
+            Type last = parameterTypes[params - 1];
+            return last instanceof Class && last.getTypeName().equals(KOTLIN_CONTINUATION)
+                    || last instanceof ParameterizedType && last.getTypeName().startsWith(KOTLIN_CONTINUATION);
+        }
+        return false;
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/fallback/KotlinFallbackTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/fallback/KotlinFallbackTest.kt
@@ -1,0 +1,18 @@
+package io.smallrye.faulttolerance.kotlin.fallback
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import io.smallrye.faulttolerance.util.WithSystemProperty
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+// so that FT methods don't have to be marked @AsynchronousNonBlocking
+@WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+@FaultToleranceBasicTest
+class KotlinFallbackTest {
+    @Test
+    fun test(service: MyService) = runBlocking<Unit> {
+        val result = service.hello("world")
+        assertThat(result).isEqualTo("Hello, WORLD")
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/fallback/MyService.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/fallback/MyService.kt
@@ -1,0 +1,19 @@
+package io.smallrye.faulttolerance.kotlin.fallback
+
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.delay
+import org.eclipse.microprofile.faulttolerance.Fallback
+
+@ApplicationScoped
+open class MyService {
+    @Fallback(fallbackMethod = "fallback")
+    open suspend fun hello(name: String): String {
+        delay(1000)
+        throw IllegalArgumentException()
+    }
+
+    open suspend fun fallback(name: String, ex: Exception): String {
+        delay(1000)
+        return "Hello, ${name.uppercase()}"
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/fallback/invalid/KotlinInvalidFallbackTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/fallback/invalid/KotlinInvalidFallbackTest.kt
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.kotlin.fallback.invalid
+
+import io.smallrye.faulttolerance.util.ExpectedDeploymentException
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import io.smallrye.faulttolerance.util.WithSystemProperty
+import jakarta.enterprise.inject.spi.DefinitionException
+import org.junit.jupiter.api.Test
+
+// so that FT methods don't have to be marked @AsynchronousNonBlocking
+@WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+@FaultToleranceBasicTest
+@ExpectedDeploymentException(DefinitionException::class)
+class KotlinInvalidFallbackTest {
+    @Test
+    fun test(ignored: MyService) {
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/fallback/invalid/MyService.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/fallback/invalid/MyService.kt
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.kotlin.fallback.invalid
+
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.delay
+import org.eclipse.microprofile.faulttolerance.Fallback
+
+@ApplicationScoped
+open class MyService {
+    @Fallback(fallbackMethod = "fallback")
+    open suspend fun hello(name: String): String {
+        throw IllegalArgumentException()
+    }
+
+    open suspend fun fallback(name: String, ex: Exception): Int {
+        return 0
+    }
+}


### PR DESCRIPTION
This commit fixes the algorithm that finds fallback methods in case of Kotlin `suspend` functions that declare an additional exception parameter. This additional parameter must be at the very end of the function signature, with the exception of Kotlin `suspend` functions, where the very last parameter must be the Kotlin `Continuation`. In this case, the exception parameter must be the _second last_.

Fixes #828