### PR TITLE
[906] Lower memory footprint and other optimisations

### DIFF
--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/BasicCircuitBreakerMaintenanceImpl.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/BasicCircuitBreakerMaintenanceImpl.java
@@ -1,7 +1,6 @@
 package io.smallrye.faulttolerance.core.apiimpl;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -16,7 +15,7 @@ import io.smallrye.faulttolerance.core.circuit.breaker.CircuitBreakerEvents;
 import io.smallrye.faulttolerance.core.util.Callbacks;
 
 public class BasicCircuitBreakerMaintenanceImpl implements CircuitBreakerMaintenance {
-    private final Set<String> knownNames = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<String> knownNames = ConcurrentHashMap.newKeySet();
     private final ConcurrentMap<String, CircuitBreaker<?>> registry = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Collection<Consumer<CircuitBreakerState>>> stateChangeCallbacks = new ConcurrentHashMap<>();
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/ThreadTimer.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/ThreadTimer.java
@@ -101,7 +101,7 @@ public final class ThreadTimer implements Timer {
                             LockSupport.parkNanos(taskStartTime - currentTime);
                         }
                     }
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     // can happen e.g. when the executor is shut down sooner than the timer
                     LOG.unexpectedExceptionInTimerLoop(e);
                 }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/TimerLogger.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/TimerLogger.java
@@ -36,5 +36,5 @@ interface TimerLogger extends BasicLogger {
 
     @Message(id = 11000, value = "Unexpected exception in timer loop, ignoring")
     @LogMessage(level = Logger.Level.WARN)
-    void unexpectedExceptionInTimerLoop(@Cause Exception e);
+    void unexpectedExceptionInTimerLoop(@Cause Throwable e);
 }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/bulkhead/timeout/fallback/AsyncCompletionStageThreadPoolBulkheadTimeoutFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/bulkhead/timeout/fallback/AsyncCompletionStageThreadPoolBulkheadTimeoutFallbackTest.java
@@ -2,7 +2,6 @@ package io.smallrye.faulttolerance.async.compstage.bulkhead.timeout.fallback;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -35,7 +34,7 @@ public class AsyncCompletionStageThreadPoolBulkheadTimeoutFallbackTest {
     private static void test(int parallelRequests, Map<String, Integer> expectedResponses, Invocation invocation)
             throws InterruptedException {
 
-        Set<String> violations = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        Set<String> violations = ConcurrentHashMap.newKeySet();
         Queue<String> seenResponses = new ConcurrentLinkedQueue<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(parallelRequests);

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/retry/circuit/breaker/fallback/AsyncCompletionStageRetryCircuitBreakerFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/retry/circuit/breaker/fallback/AsyncCompletionStageRetryCircuitBreakerFallbackTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -63,7 +62,7 @@ public class AsyncCompletionStageRetryCircuitBreakerFallbackTest {
 
     private static void test(int parallelRequests, Map<String, Range> expectedResponses, Invocation invocation)
             throws InterruptedException {
-        Set<String> violations = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        Set<String> violations = ConcurrentHashMap.newKeySet();
         Queue<String> seenResponses = new ConcurrentLinkedQueue<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(parallelRequests);


### PR DESCRIPTION
Issue https://github.com/smallrye/smallrye-fault-tolerance/issues/906

1. Collections.newSetFromMap(new ConcurrentHashMap<>()) → ConcurrentHashMap.newKeySet()
2. ThreadTimer registry for monitoring and graceful shutdown in standalone mode
3. more stable (correct) TASK_COMPARATOR
4. much less memory usage
5. prevent unexpected Thread shutdown in case of Errors and Throwables
6. better cancel for building self-made ScheduledExecutorService 
