### PR TITLE
Minor improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/BasicCircuitBreakerMaintenanceImpl.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/BasicCircuitBreakerMaintenanceImpl.java
@@ -1,7 +1,6 @@
 package io.smallrye.faulttolerance.core.apiimpl;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -16,7 +15,7 @@ import io.smallrye.faulttolerance.core.circuit.breaker.CircuitBreakerEvents;
 import io.smallrye.faulttolerance.core.util.Callbacks;
 
 public class BasicCircuitBreakerMaintenanceImpl implements CircuitBreakerMaintenance {
-    private final Set<String> knownNames = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<String> knownNames = ConcurrentHashMap.newKeySet();
     private final ConcurrentMap<String, CircuitBreaker<?>> registry = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Collection<Consumer<CircuitBreakerState>>> stateChangeCallbacks = new ConcurrentHashMap<>();
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/bulkhead/CompletionStageThreadPoolBulkhead.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/bulkhead/CompletionStageThreadPoolBulkhead.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.core.bulkhead;
 
 import static io.smallrye.faulttolerance.core.bulkhead.BulkheadLogger.LOG;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.Deque;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +56,7 @@ public class CompletionStageThreadPoolBulkhead<V> extends BulkheadBase<Completio
             LOG.debugOrTrace(description + " invocation prevented by bulkhead",
                     "Capacity semaphore not acquired, rejecting task from bulkhead");
             ctx.fireEvent(BulkheadEvents.DecisionMade.REJECTED);
-            return failedStage(bulkheadRejected());
+            return failedFuture(bulkheadRejected());
         }
     }
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/circuit/breaker/CompletionStageCircuitBreaker.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/circuit/breaker/CompletionStageCircuitBreaker.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.core.circuit.breaker;
 
 import static io.smallrye.faulttolerance.core.circuit.breaker.CircuitBreakerLogger.LOG;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -69,7 +69,7 @@ public class CompletionStageCircuitBreaker<V> extends CircuitBreaker<CompletionS
             return result;
         } catch (Throwable e) {
             inClosedHandleResult(isConsideredSuccess(e), ctx, state);
-            return failedStage(e);
+            return failedFuture(e);
         }
     }
 
@@ -78,7 +78,7 @@ public class CompletionStageCircuitBreaker<V> extends CircuitBreaker<CompletionS
             LOG.debugOrTrace(description + " invocation prevented by circuit breaker",
                     "Circuit breaker open, invocation prevented");
             ctx.fireEvent(CircuitBreakerEvents.Finished.PREVENTED);
-            return failedStage(new CircuitBreakerOpenException(description + " circuit breaker is open"));
+            return failedFuture(new CircuitBreakerOpenException(description + " circuit breaker is open"));
         } else {
             LOG.trace("Delay elapsed synchronously, circuit breaker moving to half-open");
             toHalfOpen(ctx, state);
@@ -92,7 +92,7 @@ public class CompletionStageCircuitBreaker<V> extends CircuitBreaker<CompletionS
             LOG.debugOrTrace(description + " invocation prevented by circuit breaker",
                     "Circuit breaker half-open, invocation prevented");
             ctx.fireEvent(CircuitBreakerEvents.Finished.PREVENTED);
-            return failedStage(new CircuitBreakerOpenException(description + " circuit breaker is half-open"));
+            return failedFuture(new CircuitBreakerOpenException(description + " circuit breaker is half-open"));
         }
 
         try {
@@ -113,7 +113,7 @@ public class CompletionStageCircuitBreaker<V> extends CircuitBreaker<CompletionS
             return result;
         } catch (Throwable e) {
             inHalfOpenHandleResult(isConsideredSuccess(e), ctx, state);
-            return failedStage(e);
+            return failedFuture(e);
         }
     }
 }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/fallback/CompletionStageFallback.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/fallback/CompletionStageFallback.java
@@ -1,8 +1,8 @@
 package io.smallrye.faulttolerance.core.fallback;
 
 import static io.smallrye.faulttolerance.core.fallback.FallbackLogger.LOG;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
 import static io.smallrye.faulttolerance.core.util.CompletionStages.propagateCompletion;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -36,7 +36,7 @@ public class CompletionStageFallback<V> extends Fallback<CompletionStage<V>> {
         try {
             originalResult = delegate.apply(ctx);
         } catch (Exception e) {
-            originalResult = failedStage(e);
+            originalResult = failedFuture(e);
         }
 
         originalResult.whenComplete((value, exception) -> {

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/invocation/CompletionStageSupport.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/invocation/CompletionStageSupport.java
@@ -1,6 +1,6 @@
 package io.smallrye.faulttolerance.core.invocation;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 
@@ -30,7 +30,7 @@ public class CompletionStageSupport<T> implements AsyncSupport<T, CompletionStag
         try {
             return invoker.proceed();
         } catch (Exception e) {
-            return failedStage(e);
+            return failedFuture(e);
         }
     }
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/CompletionStageMetricsCollector.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/CompletionStageMetricsCollector.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.core.metrics;
 
 import static io.smallrye.faulttolerance.core.metrics.MetricsLogger.LOG;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -34,7 +34,7 @@ public class CompletionStageMetricsCollector<V> extends MetricsCollector<Complet
         try {
             originalResult = delegate.apply(ctx);
         } catch (Exception e) {
-            originalResult = failedStage(e);
+            originalResult = failedFuture(e);
         }
 
         originalResult.whenComplete((value, exception) -> {

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/retry/CompletionStageRetry.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/retry/CompletionStageRetry.java
@@ -1,9 +1,9 @@
 package io.smallrye.faulttolerance.core.retry;
 
 import static io.smallrye.faulttolerance.core.retry.RetryLogger.LOG;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
 import static io.smallrye.faulttolerance.core.util.CompletionStages.propagateCompletion;
 import static io.smallrye.faulttolerance.core.util.Preconditions.checkNotNull;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -64,9 +64,9 @@ public class CompletionStageRetry<V> extends Retry<CompletionStage<V>> {
         } else {
             ctx.fireEvent(RetryEvents.Finished.MAX_RETRIES_REACHED);
             if (lastFailure != null) {
-                return failedStage(lastFailure);
+                return failedFuture(lastFailure);
             } else {
-                return failedStage(new FaultToleranceException(description + " reached max retries"));
+                return failedFuture(new FaultToleranceException(description + " reached max retries"));
             }
         }
     }
@@ -76,9 +76,9 @@ public class CompletionStageRetry<V> extends Retry<CompletionStage<V>> {
         if (stopwatch.elapsedTimeInMillis() > maxTotalDurationInMillis) {
             ctx.fireEvent(RetryEvents.Finished.MAX_DURATION_REACHED);
             if (lastFailure != null) {
-                return failedStage(lastFailure);
+                return failedFuture(lastFailure);
             } else {
-                return failedStage(new FaultToleranceException(description + " reached max retry duration"));
+                return failedFuture(new FaultToleranceException(description + " reached max retry duration"));
             }
         }
 
@@ -103,7 +103,7 @@ public class CompletionStageRetry<V> extends Retry<CompletionStage<V>> {
         } catch (Throwable e) {
             if (shouldAbortRetrying(e)) {
                 ctx.fireEvent(RetryEvents.Finished.EXCEPTION_NOT_RETRYABLE);
-                return failedStage(e);
+                return failedFuture(e);
             } else {
                 return doRetry(ctx, attempt + 1, delay, stopwatch, e);
             }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timeout/CompletionStageTimeout.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timeout/CompletionStageTimeout.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.core.timeout;
 
 import static io.smallrye.faulttolerance.core.timeout.TimeoutLogger.LOG;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -47,7 +47,7 @@ public class CompletionStageTimeout<V> extends Timeout<CompletionStage<V>> {
         try {
             originalResult = delegate.apply(ctx);
         } catch (Exception e) {
-            originalResult = failedStage(e);
+            originalResult = failedFuture(e);
         }
 
         originalResult.whenComplete((value, exception) -> {

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/util/CompletionStages.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/util/CompletionStages.java
@@ -8,18 +8,6 @@ import java.util.concurrent.CompletionStage;
  * Utility methods for {@link CompletionStage} and {@link CompletableFuture}.
  */
 public class CompletionStages {
-    public static <T> CompletionStage<T> completedStage(T value) {
-        return CompletableFuture.completedStage(value);
-    }
-
-    public static <T> CompletionStage<T> failedStage(Throwable exception) {
-        return CompletableFuture.failedStage(exception);
-    }
-
-    public static <T> CompletableFuture<T> failedFuture(Throwable exception) {
-        return CompletableFuture.failedFuture(exception);
-    }
-
     public static <T> void propagateCompletion(CompletionStage<T> from, CompletableFuture<T> to) {
         from.whenComplete((value, exception) -> {
             if (exception == null) {

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/util/CompletionStages.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/util/CompletionStages.java
@@ -9,17 +9,15 @@ import java.util.concurrent.CompletionStage;
  */
 public class CompletionStages {
     public static <T> CompletionStage<T> completedStage(T value) {
-        return CompletableFuture.completedFuture(value);
+        return CompletableFuture.completedStage(value);
     }
 
     public static <T> CompletionStage<T> failedStage(Throwable exception) {
-        return failedFuture(exception);
+        return CompletableFuture.failedStage(exception);
     }
 
     public static <T> CompletableFuture<T> failedFuture(Throwable exception) {
-        CompletableFuture<T> result = new CompletableFuture<>();
-        result.completeExceptionally(exception);
-        return result;
+        return CompletableFuture.failedFuture(exception);
     }
 
     public static <T> void propagateCompletion(CompletionStage<T> from, CompletableFuture<T> to) {

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/async/FutureExecutionTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/async/FutureExecutionTest.java
@@ -1,8 +1,8 @@
 package io.smallrye.faulttolerance.core.async;
 
 import static io.smallrye.faulttolerance.core.Invocation.invocation;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/circuit/breaker/CompletionStageCircuitBreakerTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/circuit/breaker/CompletionStageCircuitBreakerTest.java
@@ -1,8 +1,8 @@
 package io.smallrye.faulttolerance.core.circuit.breaker;
 
 import static io.smallrye.faulttolerance.core.Invocation.invocation;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -195,7 +195,7 @@ public class CompletionStageCircuitBreakerTest {
     }
 
     private static InvocationContext<CompletionStage<String>> returning(String value) {
-        return new InvocationContext<>(() -> completedStage(value));
+        return new InvocationContext<>(() -> completedFuture(value));
     }
 
     private static <V> InvocationContext<CompletionStage<V>> immediatelyFailingWith(Exception exception) {
@@ -205,6 +205,6 @@ public class CompletionStageCircuitBreakerTest {
     }
 
     private static <V> InvocationContext<CompletionStage<V>> eventuallyFailingWith(Exception exception) {
-        return new InvocationContext<>(() -> failedStage(exception));
+        return new InvocationContext<>(() -> failedFuture(exception));
     }
 }

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/fallback/CompletionStageFallbackTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/fallback/CompletionStageFallbackTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.core.fallback;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -28,10 +28,10 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void allExceptionsSupported_valueThenValue() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> completedStage("fallback"),
+                "test invocation", ctx -> completedFuture("fallback"),
                 ExceptionDecision.ALWAYS_FAILURE);
         CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         assertThat(result.toCompletableFuture().get()).isEqualTo("foobar");
@@ -39,7 +39,7 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void allExceptionsSupported_valueThenDirectException() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> TestException.doThrow(),
@@ -50,10 +50,10 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void allExceptionsSupported_valueThenCompletionStageException() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> failedStage(new TestException()),
+                "test invocation", ctx -> failedFuture(new TestException()),
                 ExceptionDecision.ALWAYS_FAILURE);
         CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         assertThat(result.toCompletableFuture().get()).isEqualTo("foobar");
@@ -64,7 +64,7 @@ public class CompletionStageFallbackTest {
         TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(TestException::doThrow);
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> completedStage("fallback"),
+                "test invocation", ctx -> completedFuture("fallback"),
                 ExceptionDecision.ALWAYS_FAILURE);
         CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         assertThat(result.toCompletableFuture().get()).isEqualTo("fallback");
@@ -72,10 +72,10 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void allExceptionsSupported_completionStageExceptionThenValue() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> failedStage(new TestException()));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> failedFuture(new TestException()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> completedStage("fallback"),
+                "test invocation", ctx -> completedFuture("fallback"),
                 ExceptionDecision.ALWAYS_FAILURE);
         CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         assertThat(result.toCompletableFuture().get()).isEqualTo("fallback");
@@ -100,7 +100,7 @@ public class CompletionStageFallbackTest {
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(TestException::doThrow);
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> failedStage(new RuntimeException()),
+                "test invocation", ctx -> failedFuture(new RuntimeException()),
                 ExceptionDecision.ALWAYS_FAILURE);
         CompletionStage<Void> result = fallback.apply(new InvocationContext<>(null));
         assertThatThrownBy(result.toCompletableFuture()::get)
@@ -110,7 +110,7 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void allExceptionsSupported_completionStageExceptionThenDirectException() {
-        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedStage(new TestException()));
+        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedFuture(new TestException()));
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> {
@@ -124,10 +124,10 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void allExceptionsSupported_completionStageExceptionThenCompletionStageException() {
-        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedStage(new TestException()));
+        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedFuture(new TestException()));
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> failedStage(new RuntimeException()),
+                "test invocation", ctx -> failedFuture(new RuntimeException()),
                 ExceptionDecision.ALWAYS_FAILURE);
         CompletionStage<Void> result = fallback.apply(new InvocationContext<>(null));
         assertThatThrownBy(result.toCompletableFuture()::get)
@@ -137,10 +137,10 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void noExceptionSupported_valueThenValue() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> completedStage("fallback"),
+                "test invocation", ctx -> completedFuture("fallback"),
                 ExceptionDecision.ALWAYS_EXPECTED);
         CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         assertThat(result.toCompletableFuture().get()).isEqualTo("foobar");
@@ -148,7 +148,7 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void noExceptionSupported_valueThenDirectException() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> TestException.doThrow(),
@@ -159,10 +159,10 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void noExceptionSupported_valueThenCompletionStageException() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> failedStage(new TestException()),
+                "test invocation", ctx -> failedFuture(new TestException()),
                 ExceptionDecision.ALWAYS_EXPECTED);
         CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         assertThat(result.toCompletableFuture().get()).isEqualTo("foobar");
@@ -173,7 +173,7 @@ public class CompletionStageFallbackTest {
         TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(TestException::doThrow);
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> completedStage("fallback"),
+                "test invocation", ctx -> completedFuture("fallback"),
                 ExceptionDecision.ALWAYS_EXPECTED);
         CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         assertThatThrownBy(result.toCompletableFuture()::get)
@@ -183,10 +183,10 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void noExceptionSupported_completionStageExceptionThenValue() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> failedStage(new TestException()));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> failedFuture(new TestException()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<String> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> completedStage("fallback"),
+                "test invocation", ctx -> completedFuture("fallback"),
                 ExceptionDecision.ALWAYS_EXPECTED);
         CompletionStage<String> result = fallback.apply(new InvocationContext<>(null));
         assertThatThrownBy(result.toCompletableFuture()::get)
@@ -213,7 +213,7 @@ public class CompletionStageFallbackTest {
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(TestException::doThrow);
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> failedStage(new RuntimeException()),
+                "test invocation", ctx -> failedFuture(new RuntimeException()),
                 ExceptionDecision.ALWAYS_EXPECTED);
         CompletionStage<Void> result = fallback.apply(new InvocationContext<>(null));
         assertThatThrownBy(result.toCompletableFuture()::get)
@@ -223,7 +223,7 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void noExceptionSupported_completionStageExceptionThenDirectException() {
-        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedStage(new TestException()));
+        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedFuture(new TestException()));
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
                 "test invocation", ctx -> {
@@ -237,10 +237,10 @@ public class CompletionStageFallbackTest {
 
     @Test
     public void noExceptionSupported_completionStageExceptionThenCompletionStageException() {
-        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedStage(new TestException()));
+        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedFuture(new TestException()));
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageFallback<Void> fallback = new CompletionStageFallback<>(execution,
-                "test invocation", ctx -> failedStage(new RuntimeException()),
+                "test invocation", ctx -> failedFuture(new RuntimeException()),
                 ExceptionDecision.ALWAYS_EXPECTED);
         CompletionStage<Void> result = fallback.apply(new InvocationContext<>(null));
         assertThatThrownBy(result.toCompletableFuture()::get)

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/fallback/FutureFallbackTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/fallback/FutureFallbackTest.java
@@ -1,8 +1,8 @@
 package io.smallrye.faulttolerance.core.fallback;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
 import static io.smallrye.faulttolerance.core.util.TestThread.runOnTestThread;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/rate/limit/CompletionStageRateLimitTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/rate/limit/CompletionStageRateLimitTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.core.rate.limit;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
 import static io.smallrye.faulttolerance.core.util.TestThread.runOnTestThread;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -49,7 +49,7 @@ public class CompletionStageRateLimitTest {
     public void fixed_singleThreaded() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 2, 100, 0, RateLimitType.FIXED, stopwatch);
@@ -86,7 +86,7 @@ public class CompletionStageRateLimitTest {
     public void fixed_multiThreaded() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 2, 100, 0, RateLimitType.FIXED, stopwatch);
@@ -146,7 +146,7 @@ public class CompletionStageRateLimitTest {
     public void fixed_multiThreaded_withMinSpacing() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 2, 100, 10, RateLimitType.FIXED, stopwatch);
@@ -211,7 +211,7 @@ public class CompletionStageRateLimitTest {
     public void rolling_singleThreaded() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 2, 100, 0, RateLimitType.ROLLING, stopwatch);
@@ -246,7 +246,7 @@ public class CompletionStageRateLimitTest {
     public void rolling_multiThreaded() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 2, 100, 0, RateLimitType.ROLLING, stopwatch);
@@ -311,7 +311,7 @@ public class CompletionStageRateLimitTest {
     public void rolling_multiThreaded_withMinSpacing() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 2, 100, 10, RateLimitType.ROLLING, stopwatch);
@@ -376,7 +376,7 @@ public class CompletionStageRateLimitTest {
     public void smooth_singleThreaded() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 2, 100, 0, RateLimitType.SMOOTH, stopwatch);
@@ -412,7 +412,7 @@ public class CompletionStageRateLimitTest {
     public void smooth_multiThreaded() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 2, 100, 0, RateLimitType.SMOOTH, stopwatch);
@@ -475,7 +475,7 @@ public class CompletionStageRateLimitTest {
     public void smooth_multiThreaded_withMinSpacing() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         TestInvocation<CompletionStage<String>> invocation = TestInvocation
-                .of(() -> completedStage("" + counter.incrementAndGet()));
+                .of(() -> completedFuture("" + counter.incrementAndGet()));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageRateLimit<String> rateLimit = new CompletionStageRateLimit<>(execution, "test invocation",
                 1000, 100, 10, RateLimitType.SMOOTH, stopwatch);

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/retry/FutureRetryTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/retry/FutureRetryTest.java
@@ -1,8 +1,8 @@
 package io.smallrye.faulttolerance.core.retry;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
 import static io.smallrye.faulttolerance.core.util.TestThread.runOnTestThread;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/CompletionStageTimeoutTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/CompletionStageTimeoutTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.core.timeout;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -48,7 +48,7 @@ public class CompletionStageTimeoutTest {
 
     @Test
     public void negativeTimeout() {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         assertThatThrownBy(() -> new CompletionStageTimeout<>(execution, "test invocation", -1, timeoutWatcher))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
@@ -56,7 +56,7 @@ public class CompletionStageTimeoutTest {
 
     @Test
     public void zeroTimeout() {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         assertThatThrownBy(() -> new CompletionStageTimeout<>(execution, "test invocation", 0, timeoutWatcher))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
@@ -64,7 +64,7 @@ public class CompletionStageTimeoutTest {
 
     @Test
     public void immediatelyReturning_value() throws Exception {
-        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedStage("foobar"));
+        TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> completedFuture("foobar"));
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<String> timeout = new CompletionStageTimeout<>(execution,
                 "test invocation", 1000, timeoutWatcher);
@@ -88,7 +88,7 @@ public class CompletionStageTimeoutTest {
 
     @Test
     public void immediatelyReturning_completionStageException() {
-        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedStage(new TestException()));
+        TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> failedFuture(new TestException()));
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<Void> timeout = new CompletionStageTimeout<>(execution,
                 "test invocation", 1000, timeoutWatcher);
@@ -105,7 +105,7 @@ public class CompletionStageTimeoutTest {
 
         TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> {
             delayBarrier.await();
-            return completedStage("foobar");
+            return completedFuture("foobar");
         });
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<String> timeout = new CompletionStageTimeout<>(execution,
@@ -122,7 +122,7 @@ public class CompletionStageTimeoutTest {
 
         TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> {
             delayBarrier.await();
-            return completedStage("foobar");
+            return completedFuture("foobar");
         });
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<String> timeout = new CompletionStageTimeout<>(execution,
@@ -143,7 +143,7 @@ public class CompletionStageTimeoutTest {
 
         TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> {
             delayBarrier.await();
-            return completedStage("foobar");
+            return completedFuture("foobar");
         });
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<String> timeout = new CompletionStageTimeout<>(execution,
@@ -165,7 +165,7 @@ public class CompletionStageTimeoutTest {
 
         TestInvocation<CompletionStage<String>> invocation = TestInvocation.of(() -> {
             party.participant().attend();
-            return completedStage("foobar");
+            return completedFuture("foobar");
         });
         CompletionStageExecution<String> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<String> timeout = new CompletionStageTimeout<>(execution,
@@ -185,7 +185,7 @@ public class CompletionStageTimeoutTest {
 
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> {
             delayBarrier.await();
-            return failedStage(new TestException());
+            return failedFuture(new TestException());
         });
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<Void> timeout = new CompletionStageTimeout<>(execution,
@@ -204,7 +204,7 @@ public class CompletionStageTimeoutTest {
 
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> {
             delayBarrier.await();
-            return failedStage(new TestException());
+            return failedFuture(new TestException());
         });
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<Void> timeout = new CompletionStageTimeout<>(execution,
@@ -225,7 +225,7 @@ public class CompletionStageTimeoutTest {
 
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> {
             delayBarrier.await();
-            return failedStage(new TestException());
+            return failedFuture(new TestException());
         });
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<Void> timeout = new CompletionStageTimeout<>(execution,
@@ -247,7 +247,7 @@ public class CompletionStageTimeoutTest {
 
         TestInvocation<CompletionStage<Void>> invocation = TestInvocation.of(() -> {
             party.participant().attend();
-            return failedStage(new TestException());
+            return failedFuture(new TestException());
         });
         CompletionStageExecution<Void> execution = new CompletionStageExecution<>(invocation, executor);
         CompletionStageTimeout<Void> timeout = new CompletionStageTimeout<>(execution,

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/RealWorldCompletionStageTimeoutTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/RealWorldCompletionStageTimeoutTest.java
@@ -1,8 +1,8 @@
 package io.smallrye.faulttolerance.core.timeout;
 
 import static io.smallrye.faulttolerance.core.Invocation.invocation;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Percentage.withPercentage;
@@ -79,7 +79,7 @@ public class RealWorldCompletionStageTimeoutTest {
 
         assertThat(timeout.apply(new InvocationContext<>(() -> {
             Thread.sleep(SLEEP_TIME);
-            return completedStage("foobar");
+            return completedFuture("foobar");
         })).toCompletableFuture().get()).isEqualTo("foobar");
         assertThat(runningStopwatch.elapsedTimeInMillis()).isCloseTo(SLEEP_TIME, tolerance);
     }
@@ -111,7 +111,7 @@ public class RealWorldCompletionStageTimeoutTest {
 
         assertThatThrownBy(timeout.apply(new InvocationContext<>(() -> {
             Thread.sleep(SLEEP_TIME);
-            return failedStage(new TestException());
+            return failedFuture(new TestException());
         })).toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(TestException.class);
@@ -128,7 +128,7 @@ public class RealWorldCompletionStageTimeoutTest {
 
         assertThatThrownBy(timeout.apply(new InvocationContext<>(() -> {
             Thread.sleep(TIMEOUT);
-            return completedStage("foobar");
+            return completedFuture("foobar");
         })).toCompletableFuture()::get)
                 .isExactlyInstanceOf(ExecutionException.class)
                 .hasCauseExactlyInstanceOf(TimeoutException.class);

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/MicroProfileMetricsProvider.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/MicroProfileMetricsProvider.java
@@ -90,6 +90,7 @@ public class MicroProfileMetricsProvider implements MetricsProvider {
     @Inject
     SpecCompatibility specCompatibility;
 
+    @Override
     public MetricsRecorder create(FaultToleranceOperation operation) {
         if (metricsEnabled) {
             return new MetricsRecorderImpl(registry, specCompatibility, operation);
@@ -98,6 +99,7 @@ public class MicroProfileMetricsProvider implements MetricsProvider {
         }
     }
 
+    @Override
     public boolean isEnabled() {
         return metricsEnabled;
     }

--- a/implementation/kotlin/src/main/kotlin/io/smallrye/faulttolerance/kotlin/impl/CoroutineSupport.kt
+++ b/implementation/kotlin/src/main/kotlin/io/smallrye/faulttolerance/kotlin/impl/CoroutineSupport.kt
@@ -2,10 +2,10 @@ package io.smallrye.faulttolerance.kotlin.impl
 
 import io.smallrye.faulttolerance.core.invocation.AsyncSupport
 import io.smallrye.faulttolerance.core.invocation.Invoker
-import io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletableFuture.completedFuture
+import java.util.concurrent.CompletableFuture.failedFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.ExecutionException
 import kotlin.coroutines.Continuation

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneBulkheadAsyncEventsTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneBulkheadAsyncEventsTest.java
@@ -1,6 +1,6 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -38,7 +38,7 @@ public class StandaloneBulkheadAsyncEventsTest {
         for (int i = 0; i < 10; i++) {
             guarded.call(() -> {
                 party.participant().attend();
-                return completedStage("ignored");
+                return completedFuture("ignored");
             });
         }
 
@@ -49,7 +49,7 @@ public class StandaloneBulkheadAsyncEventsTest {
         assertThat(finishedCounter).hasValue(0);
 
         for (int i = 0; i < 3; i++) {
-            assertThat(guarded.call(() -> completedStage("value")))
+            assertThat(guarded.call(() -> completedFuture("value")))
                     .succeedsWithin(10, TimeUnit.SECONDS)
                     .isEqualTo("fallback");
         }
@@ -66,6 +66,6 @@ public class StandaloneBulkheadAsyncEventsTest {
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneBulkheadAsyncTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneBulkheadAsyncTest.java
@@ -1,6 +1,6 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletionStage;
@@ -26,13 +26,13 @@ public class StandaloneBulkheadAsyncTest {
         for (int i = 0; i < 10; i++) {
             guarded.call(() -> {
                 party.participant().attend();
-                return completedStage("ignored");
+                return completedFuture("ignored");
             });
         }
 
         party.organizer().waitForAll();
 
-        assertThat(guarded.call(() -> completedStage("value")))
+        assertThat(guarded.call(() -> completedFuture("value")))
                 .succeedsWithin(10, TimeUnit.SECONDS)
                 .isEqualTo("fallback");
 
@@ -40,6 +40,6 @@ public class StandaloneBulkheadAsyncTest {
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneCircuitBreakerAsyncEventsTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneCircuitBreakerAsyncEventsTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletionStage;
@@ -78,13 +78,13 @@ public class StandaloneCircuitBreakerAsyncEventsTest {
 
     public CompletionStage<String> action() {
         if (actionShouldFail) {
-            return failedStage(new TestException());
+            return failedFuture(new TestException());
         } else {
-            return completedStage("value");
+            return completedFuture("value");
         }
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneCircuitBreakerAsyncTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneCircuitBreakerAsyncTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletionStage;
@@ -102,10 +102,10 @@ public class StandaloneCircuitBreakerAsyncTest {
     }
 
     public CompletionStage<String> action() {
-        return failedStage(new TestException());
+        return failedFuture(new TestException());
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneFallbackAsyncTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneFallbackAsyncTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletionStage;
@@ -29,7 +29,7 @@ public class StandaloneFallbackAsyncTest {
     @Test
     public void asyncFallbackWithFunction() {
         Supplier<CompletionStage<String>> guarded = FaultTolerance.createAsyncSupplier(this::action)
-                .withFallback().handler(e -> completedStage(e.getClass().getSimpleName())).done()
+                .withFallback().handler(e -> completedFuture(e.getClass().getSimpleName())).done()
                 .build();
 
         assertThat(guarded.get())
@@ -88,10 +88,10 @@ public class StandaloneFallbackAsyncTest {
     }
 
     public CompletionStage<String> action() {
-        return failedStage(new TestException());
+        return failedFuture(new TestException());
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandalonePassthroughAsyncTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandalonePassthroughAsyncTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -129,11 +129,11 @@ public class StandalonePassthroughAsyncTest {
     }
 
     private CompletionStage<String> completeSuccessfully() {
-        return completedStage("value");
+        return completedFuture("value");
     }
 
     private CompletionStage<String> completeExceptionally() {
-        return failedStage(new TestException());
+        return failedFuture(new TestException());
     }
 
     private CompletionStage<String> throwException() throws TestException {

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneRateLimitAsyncEventsTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneRateLimitAsyncEventsTest.java
@@ -1,6 +1,5 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,6 +74,6 @@ public class StandaloneRateLimitAsyncEventsTest {
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneRateLimitAsyncTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneRateLimitAsyncTest.java
@@ -1,6 +1,5 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,6 +62,6 @@ public class StandaloneRateLimitAsyncTest {
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneRetryAsyncEventsTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneRetryAsyncEventsTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletionStage;
@@ -53,13 +53,13 @@ public class StandaloneRetryAsyncEventsTest {
     public CompletionStage<String> action() {
         if (failTimes > 0) {
             failTimes--;
-            return failedStage(new TestException());
+            return failedFuture(new TestException());
         }
 
-        return completedStage("value");
+        return completedFuture("value");
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneRetryAsyncTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneRetryAsyncTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletionStage;
@@ -94,10 +94,10 @@ public class StandaloneRetryAsyncTest {
 
     public CompletionStage<String> action() {
         counter.incrementAndGet();
-        return failedStage(new TestException());
+        return failedFuture(new TestException());
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneTimeoutAsyncEventsTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneTimeoutAsyncEventsTest.java
@@ -1,6 +1,6 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.temporal.ChronoUnit;
@@ -51,10 +51,10 @@ public class StandaloneTimeoutAsyncEventsTest {
         if (shouldSleep) {
             Thread.sleep(10_000);
         }
-        return completedStage("value");
+        return completedFuture("value");
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneTimeoutAsyncTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneTimeoutAsyncTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.standalone.test;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
 import static io.smallrye.faulttolerance.core.util.Timing.timed;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withinPercentage;
 
@@ -34,10 +34,10 @@ public class StandaloneTimeoutAsyncTest {
 
     public CompletionStage<String> action() throws InterruptedException {
         Thread.sleep(10_000);
-        return completedStage("value");
+        return completedFuture("value");
     }
 
     public CompletionStage<String> fallback() {
-        return completedStage("fallback");
+        return completedFuture("fallback");
     }
 }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/asyncnonblocking/fallback/FallbackAsyncNonBlockingHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/asyncnonblocking/fallback/FallbackAsyncNonBlockingHelloService.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.async.additional.asyncnonblocking.fallback;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/asyncnonblocking/retry/RetryAsyncNonBlockingHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/asyncnonblocking/retry/RetryAsyncNonBlockingHelloService.java
@@ -1,6 +1,6 @@
 package io.smallrye.faulttolerance.async.additional.asyncnonblocking.retry;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/blocking/fallback/FallbackBlockingHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/blocking/fallback/FallbackBlockingHelloService.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.async.additional.blocking.fallback;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/blocking/retry/RetryBlockingHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/blocking/retry/RetryBlockingHelloService.java
@@ -1,6 +1,6 @@
 package io.smallrye.faulttolerance.async.additional.blocking.retry;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/nonblocking/fallback/FallbackNonblockingHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/nonblocking/fallback/FallbackNonblockingHelloService.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.async.additional.nonblocking.fallback;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/nonblocking/retry/RetryNonblockingHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/additional/nonblocking/retry/RetryNonblockingHelloService.java
@@ -1,6 +1,6 @@
 package io.smallrye.faulttolerance.async.additional.nonblocking.retry;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/bulkhead/timeout/fallback/AsyncCompletionStageThreadPoolBulkheadTimeoutFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/bulkhead/timeout/fallback/AsyncCompletionStageThreadPoolBulkheadTimeoutFallbackTest.java
@@ -2,7 +2,6 @@ package io.smallrye.faulttolerance.async.compstage.bulkhead.timeout.fallback;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -35,7 +34,7 @@ public class AsyncCompletionStageThreadPoolBulkheadTimeoutFallbackTest {
     private static void test(int parallelRequests, Map<String, Integer> expectedResponses, Invocation invocation)
             throws InterruptedException {
 
-        Set<String> violations = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        Set<String> violations = ConcurrentHashMap.newKeySet();
         Queue<String> seenResponses = new ConcurrentLinkedQueue<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(parallelRequests);

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/failon/halfopen/AsyncHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/failon/halfopen/AsyncHelloService.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.async.compstage.circuit.breaker.failon.halfopen;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -24,9 +24,9 @@ public class AsyncHelloService {
         counter.incrementAndGet();
 
         if (e == null) {
-            return completedStage("Hello, world!");
+            return completedFuture("Hello, world!");
         }
-        return failedStage(e);
+        return failedFuture(e);
     }
 
     AtomicInteger getCounter() {

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/halfopen/AsyncHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/halfopen/AsyncHelloService.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.async.compstage.circuit.breaker.halfopen;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,14 +27,14 @@ public class AsyncHelloService {
         counter.incrementAndGet();
 
         if (fail) {
-            return failedStage(new IllegalArgumentException());
+            return failedFuture(new IllegalArgumentException());
         }
 
         if (participant != null) {
             participant.attend();
         }
 
-        return completedStage("Hello, world!");
+        return completedFuture("Hello, world!");
     }
 
     AtomicInteger getCounter() {

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/timer/halfopen/AsyncHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/circuit/breaker/timer/halfopen/AsyncHelloService.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.async.compstage.circuit.breaker.timer.halfopen;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.completedStage;
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedStage;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 
@@ -22,9 +22,9 @@ public class AsyncHelloService {
     @CircuitBreakerName("hello")
     public CompletionStage<String> hello(boolean fail) {
         if (fail) {
-            return failedStage(new IllegalArgumentException());
+            return failedFuture(new IllegalArgumentException());
         }
 
-        return completedStage("Hello, world!");
+        return completedFuture("Hello, world!");
     }
 }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/retry/circuit/breaker/fallback/AsyncCompletionStageRetryCircuitBreakerFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/compstage/retry/circuit/breaker/fallback/AsyncCompletionStageRetryCircuitBreakerFallbackTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -63,7 +62,7 @@ public class AsyncCompletionStageRetryCircuitBreakerFallbackTest {
 
     private static void test(int parallelRequests, Map<String, Range> expectedResponses, Invocation invocation)
             throws InterruptedException {
-        Set<String> violations = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        Set<String> violations = ConcurrentHashMap.newKeySet();
         Queue<String> seenResponses = new ConcurrentLinkedQueue<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(parallelRequests);

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/noncompatible/NoncompatibleNonblockingHelloService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/async/noncompatible/NoncompatibleNonblockingHelloService.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.async.noncompatible;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/MyService.java
@@ -1,6 +1,6 @@
 package io.smallrye.faulttolerance.reuse.async.completionstage;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/MyService.java
@@ -1,7 +1,7 @@
 package io.smallrye.faulttolerance.reuse.mixed.async.completionstage;
 
-import static io.smallrye.faulttolerance.core.util.CompletionStages.failedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/testsuite/integration/src/test/java/io/smallrye/faulttolerance/vertx/retry/MyService.java
+++ b/testsuite/integration/src/test/java/io/smallrye/faulttolerance/vertx/retry/MyService.java
@@ -1,5 +1,7 @@
 package io.smallrye.faulttolerance.vertx.retry;
 
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
 import java.time.temporal.ChronoUnit;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -12,7 +14,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
-import io.smallrye.faulttolerance.core.util.CompletionStages;
 
 @ApplicationScoped
 public class MyService {
@@ -29,6 +30,6 @@ public class MyService {
         if (current > 10) {
             return CompletableFuture.completedFuture("Hello!");
         }
-        return CompletionStages.failedStage(new Exception());
+        return failedFuture(new Exception());
     }
 }

--- a/testsuite/integration/src/test/java/io/smallrye/faulttolerance/vertx/retry/fallback/MyService.java
+++ b/testsuite/integration/src/test/java/io/smallrye/faulttolerance/vertx/retry/fallback/MyService.java
@@ -1,8 +1,10 @@
 package io.smallrye.faulttolerance.vertx.retry.fallback;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
 import java.time.temporal.ChronoUnit;
 import java.util.Queue;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -12,7 +14,6 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import io.smallrye.common.annotation.NonBlocking;
-import io.smallrye.faulttolerance.core.util.CompletionStages;
 
 @ApplicationScoped
 public class MyService {
@@ -23,11 +24,11 @@ public class MyService {
     @Fallback(fallbackMethod = "fallback")
     public CompletionStage<String> hello() {
         invocationThreads.add(Thread.currentThread().getName());
-        return CompletionStages.failedStage(new Exception());
+        return failedFuture(new Exception());
     }
 
     public CompletionStage<String> fallback() {
         invocationThreads.add(Thread.currentThread().getName());
-        return CompletableFuture.completedFuture("Hello fallback!");
+        return completedFuture("Hello fallback!");
     }
 }

--- a/testsuite/integration/src/test/java/io/smallrye/faulttolerance/vertx/retry/requestcontext/MyService.java
+++ b/testsuite/integration/src/test/java/io/smallrye/faulttolerance/vertx/retry/requestcontext/MyService.java
@@ -1,5 +1,7 @@
 package io.smallrye.faulttolerance.vertx.retry.requestcontext;
 
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
 import java.time.temporal.ChronoUnit;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -13,7 +15,6 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
-import io.smallrye.faulttolerance.core.util.CompletionStages;
 
 @ApplicationScoped
 public class MyService {
@@ -35,6 +36,6 @@ public class MyService {
         if (current > 10) {
             return CompletableFuture.completedFuture("Hello!");
         }
-        return CompletionStages.failedStage(new Exception());
+        return failedFuture(new Exception());
     }
 }


### PR DESCRIPTION
1. FaultTolerance.complete as in https://github.com/smallrye/smallrye-fault-tolerance/issues/908
2. Collections.newSetFromMap(new ConcurrentHashMap<>()) → ConcurrentHashMap.newKeySet()
3. CompletionStages 3 lines to 1 (CompletableFuture.failedFuture)
4. .editorconfig
5. support of https://jitpack.io/ (It works: https://jitpack.io/#magicprinc/smallrye-fault-tolerance/6.2.6 )