### PR TITLE
FaultToleranceImpl.BuilderImpl.withThreadOffload: allow disabling in sync mode

### DIFF
--- a/api/src/main/java/io/smallrye/faulttolerance/api/FaultTolerance.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/FaultTolerance.java
@@ -300,9 +300,9 @@ public interface FaultTolerance<T> {
         TimeoutBuilder<T, R> withTimeout();
 
         /**
-         * Configures whether the guarded action should be offloaded to another thread. This is only possible
-         * for asynchronous actions. If this builder was not created using {@code createAsync}, this method
-         * throws an exception.
+         * Configures whether the guarded action should be offloaded to another thread. Thread offload is
+         * only possible for asynchronous actions. If this builder was not created using {@code createAsync},
+         * attempting to configure thread offload throws an exception.
          *
          * @param value whether the guarded action should be offloaded to another thread
          * @return this fault tolerance builder

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
@@ -177,7 +177,7 @@ public final class FaultToleranceImpl<V, S, T> implements FaultTolerance<T> {
 
         @Override
         public Builder<T, R> withThreadOffload(boolean value) {
-            if (!isAsync) {
+            if (!isAsync && value) {
                 throw new IllegalStateException("Thread offload may only be set for asynchronous invocations");
             }
 


### PR DESCRIPTION
FaultToleranceImpl.BuilderImpl.withThreadOffload

withThreadOffload(false) must be allowed in any mode (sync or async)