### PR TITLE
add FaultTolerance.Builder.withThreadOffloadExecutor()

### DIFF
--- a/api/src/main/java/io/smallrye/faulttolerance/api/AsynchronousNonBlocking.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/AsynchronousNonBlocking.java
@@ -28,9 +28,9 @@ import io.smallrye.common.annotation.Experimental;
  * the result of the asynchronous execution, when it completes.
  * <p>
  * Before the asynchronous execution completes, the {@code CompletionStage} returned to the caller is incomplete.
- * Once the asynchronous execution completes, the {@code CompletionStage} returned to the caller assumes behavior
- * that is equivalent to the {@code CompletionStage} returned by the guarded method. If the guarded method
- * synchronously throws an exception, the returned {@code CompletionStage} completes with that exception.
+ * Once the asynchronous execution completes, the {@code CompletionStage} returned to the caller becomes equivalent
+ * to the {@code CompletionStage} returned by the guarded method. If the guarded method synchronously throws
+ * an exception, the returned {@code CompletionStage} completes with that exception.
  * <p>
  * If a method marked with this annotation doesn't declare return type of {@code CompletionStage},
  * {@link org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException

--- a/api/src/main/java/io/smallrye/faulttolerance/api/FaultTolerance.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/FaultTolerance.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -302,7 +303,7 @@ public interface FaultTolerance<T> {
         /**
          * Configures whether the guarded action should be offloaded to another thread. Thread offload is
          * only possible for asynchronous actions. If this builder was not created using {@code createAsync},
-         * attempting to configure thread offload throws an exception.
+         * attempting to enable thread offload throws an exception.
          *
          * @param value whether the guarded action should be offloaded to another thread
          * @return this fault tolerance builder
@@ -310,6 +311,19 @@ public interface FaultTolerance<T> {
          * @see AsynchronousNonBlocking @AsynchronousNonBlocking
          */
         Builder<T, R> withThreadOffload(boolean value);
+
+        /**
+         * Configures the executor to use when offloading the guarded action to another thread. Thread
+         * offload is only possible for asynchronous actions. If this builder was not created using
+         * {@code createAsync}, this method throws an exception.
+         * <p>
+         * If this method is not called, the guarded action is offloaded to the default executor
+         * provided by the integrator.
+         *
+         * @param executor the executor to which the guarded action should be offloaded
+         * @return this fault tolerance builder
+         */
+        Builder<T, R> withThreadOffloadExecutor(Executor executor);
 
         /**
          * Returns a ready-to-use instance of {@code FaultTolerance} or guarded {@code Callable}, depending on

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/RememberEventLoop.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/RememberEventLoop.java
@@ -1,6 +1,7 @@
 package io.smallrye.faulttolerance.core.async;
 
 import static io.smallrye.faulttolerance.core.async.AsyncLogger.LOG;
+import static io.smallrye.faulttolerance.core.util.Preconditions.checkNotNull;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -15,7 +16,7 @@ public class RememberEventLoop<V> implements FaultToleranceStrategy<CompletionSt
 
     public RememberEventLoop(FaultToleranceStrategy<CompletionStage<V>> delegate, EventLoop eventLoop) {
         this.delegate = delegate;
-        this.eventLoop = eventLoop;
+        this.eventLoop = checkNotNull(eventLoop, "Event loop must be set");
     }
 
     @Override

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneThreadOffloadTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneThreadOffloadTest.java
@@ -1,0 +1,78 @@
+package io.smallrye.faulttolerance.standalone.test;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.api.FaultTolerance;
+import io.smallrye.faulttolerance.core.util.party.Party;
+
+public class StandaloneThreadOffloadTest {
+    @Test
+    public void integratedExecutor() throws Exception {
+        FaultTolerance<CompletionStage<String>> guarded = FaultTolerance.<String> createAsync()
+                .withThreadOffload(true)
+                .build();
+
+        Set<String> threadNames = ConcurrentHashMap.newKeySet();
+        Party party = Party.create(5);
+
+        for (int i = 0; i < 5; i++) {
+            guarded.call(() -> {
+                threadNames.add(Thread.currentThread().getName());
+                party.participant().attend();
+                return completedFuture("ignored");
+            });
+        }
+
+        party.organizer().waitForAll();
+        party.organizer().disband();
+
+        assertThat(threadNames).hasSize(5);
+    }
+
+    @Test
+    public void explicitExecutor() throws Exception {
+        String prefix = UUID.randomUUID().toString();
+        AtomicInteger counter = new AtomicInteger();
+        ExecutorService executor = Executors.newCachedThreadPool(runnable -> new Thread(runnable,
+                prefix + "_" + counter.incrementAndGet()));
+
+        FaultTolerance<CompletionStage<String>> guarded = FaultTolerance.<String> createAsync()
+                .withThreadOffload(true)
+                .withThreadOffloadExecutor(executor)
+                .build();
+
+        Set<String> threadNames = ConcurrentHashMap.newKeySet();
+        Party party = Party.create(5);
+
+        for (int i = 0; i < 5; i++) {
+            guarded.call(() -> {
+                threadNames.add(Thread.currentThread().getName());
+                party.participant().attend();
+                return completedFuture("ignored");
+            });
+        }
+
+        party.organizer().waitForAll();
+        party.organizer().disband();
+
+        assertThat(threadNames).hasSize(5);
+        assertThat(threadNames).allSatisfy(threadName -> {
+            assertThat(threadName).startsWith(prefix);
+        });
+
+        executor.shutdownNow();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/programmatic/CdiThreadOffloadTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/programmatic/CdiThreadOffloadTest.java
@@ -1,0 +1,8 @@
+package io.smallrye.faulttolerance.programmatic;
+
+import io.smallrye.faulttolerance.standalone.test.StandaloneThreadOffloadTest;
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class CdiThreadOffloadTest extends StandaloneThreadOffloadTest {
+}


### PR DESCRIPTION
This method allows configuring the executor to use for thread offloads of actions guarded by the built `FaultTolerance` instance.

Fixes #988