### PR TITLE
fix FaultTolerance.run() causing a NPE in async mode

### DIFF
--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
@@ -114,6 +114,21 @@ public final class FaultToleranceImpl<V, S, T> implements FaultTolerance<T> {
         return asyncSupport.fromCompletionStage(wrapper);
     }
 
+    @Override
+    public void run(Runnable action) {
+        try {
+            T unusedResult = asyncSupport == null ? null : asyncSupport.createComplete(null);
+            call(() -> {
+                action.run();
+                return unusedResult;
+            });
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static final class BuilderImpl<T, R> implements Builder<T, R> {
         private final BuilderEagerDependencies eagerDependencies;
         private final Supplier<BuilderLazyDependencies> lazyDependencies;

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/LazyFaultTolerance.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/LazyFaultTolerance.java
@@ -22,14 +22,30 @@ public final class LazyFaultTolerance<T> implements FaultTolerance<T> {
 
     @Override
     public T call(Callable<T> action) throws Exception {
+        return instance().call(action);
+    }
+
+    @Override
+    public T get(Supplier<T> action) {
+        return instance().get(action);
+    }
+
+    @Override
+    public void run(Runnable action) {
+        instance().run(action);
+    }
+
+    private FaultTolerance<T> instance() {
+        FaultTolerance<T> instance = this.instance;
         if (instance == null) {
             synchronized (this) {
+                instance = this.instance;
                 if (instance == null) {
                     instance = builder.get();
+                    this.instance = instance;
                 }
             }
         }
-
-        return instance.call(action);
+        return instance;
     }
 }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/invocation/AsyncSupport.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/invocation/AsyncSupport.java
@@ -11,6 +11,8 @@ public interface AsyncSupport<V, AT> {
 
     boolean applies(Class<?>[] parameterTypes, Class<?> returnType);
 
+    AT createComplete(V value);
+
     CompletionStage<V> toCompletionStage(Invoker<AT> invoker) throws Exception;
 
     AT fromCompletionStage(Invoker<CompletionStage<V>> invoker) throws Exception;

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/invocation/CompletionStageSupport.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/invocation/CompletionStageSupport.java
@@ -1,5 +1,6 @@
 package io.smallrye.faulttolerance.core.invocation;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import java.util.concurrent.CompletionStage;
@@ -18,6 +19,11 @@ public class CompletionStageSupport<T> implements AsyncSupport<T, CompletionStag
     @Override
     public boolean applies(Class<?>[] parameterTypes, Class<?> returnType) {
         return CompletionStage.class.equals(returnType);
+    }
+
+    @Override
+    public CompletionStage<T> createComplete(T value) {
+        return completedFuture(value);
     }
 
     @Override

--- a/implementation/kotlin/src/main/kotlin/io/smallrye/faulttolerance/kotlin/impl/CoroutineSupport.kt
+++ b/implementation/kotlin/src/main/kotlin/io/smallrye/faulttolerance/kotlin/impl/CoroutineSupport.kt
@@ -29,6 +29,10 @@ class CoroutineSupport<T> : AsyncSupport<T, Any?> {
         return parameterTypes.isNotEmpty() && parameterTypes.last() == Continuation::class.java
     }
 
+    override fun createComplete(value: T): Any? {
+        return value
+    }
+
     override fun toCompletionStage(invoker: Invoker<Any?>): CompletionStage<T> {
         val future = CompletableFuture<T>()
 

--- a/implementation/mutiny/src/main/java/io/smallrye/faulttolerance/mutiny/impl/UniSupport.java
+++ b/implementation/mutiny/src/main/java/io/smallrye/faulttolerance/mutiny/impl/UniSupport.java
@@ -25,6 +25,11 @@ public class UniSupport<T> implements AsyncSupport<T, Uni<T>> {
     }
 
     @Override
+    public Uni<T> createComplete(T value) {
+        return Uni.createFrom().item(value);
+    }
+
+    @Override
     public CompletionStage<T> toCompletionStage(Invoker<Uni<T>> invoker) throws Exception {
         return invoker.proceed().subscribeAsCompletionStage();
     }

--- a/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/CompletableSupport.java
+++ b/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/CompletableSupport.java
@@ -23,6 +23,11 @@ public class CompletableSupport<T> implements AsyncSupport<T, Completable> {
     }
 
     @Override
+    public Completable createComplete(T value) {
+        return Completable.complete();
+    }
+
+    @Override
     public CompletionStage<T> toCompletionStage(Invoker<Completable> invoker) throws Exception {
         return invoker.proceed().toCompletionStage(null);
     }

--- a/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/MaybeSupport.java
+++ b/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/MaybeSupport.java
@@ -23,6 +23,11 @@ public class MaybeSupport<T> implements AsyncSupport<T, Maybe<T>> {
     }
 
     @Override
+    public Maybe<T> createComplete(T value) {
+        return Maybe.just(value);
+    }
+
+    @Override
     public CompletionStage<T> toCompletionStage(Invoker<Maybe<T>> invoker) throws Exception {
         return invoker.proceed().toCompletionStage(null);
     }

--- a/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/SingleSupport.java
+++ b/implementation/rxjava3/src/main/java/io/smallrye/faulttolerance/rxjava3/impl/SingleSupport.java
@@ -23,6 +23,11 @@ public class SingleSupport<T> implements AsyncSupport<T, Single<T>> {
     }
 
     @Override
+    public Single<T> createComplete(T value) {
+        return Single.just(value);
+    }
+
+    @Override
     public CompletionStage<T> toCompletionStage(Invoker<Single<T>> invoker) throws Exception {
         return invoker.proceed().toCompletionStage();
     }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneMetricsTimerTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneMetricsTimerTest.java
@@ -91,10 +91,10 @@ public class StandaloneMetricsTimerTest {
 
     public CompletionStage<String> action() throws InterruptedException {
         barrier.await();
-        return CompletableFuture.completedStage("hello");
+        return CompletableFuture.completedFuture("hello");
     }
 
     public CompletionStage<String> fallback() {
-        return CompletableFuture.completedStage("fallback");
+        return CompletableFuture.completedFuture("fallback");
     }
 }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/programmatic/CdiMetricsTimerTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/programmatic/CdiMetricsTimerTest.java
@@ -56,10 +56,10 @@ public class CdiMetricsTimerTest {
 
     public CompletionStage<String> action() throws InterruptedException {
         barrier.await();
-        return CompletableFuture.completedStage("hello");
+        return CompletableFuture.completedFuture("hello");
     }
 
     public CompletionStage<String> fallback() {
-        return CompletableFuture.completedStage("fallback");
+        return CompletableFuture.completedFuture("fallback");
     }
 }


### PR DESCRIPTION
The previous implementation of `FaultTolerance.run()` simply delegated to `call()` with a `Callable` that produces `null`. In the async mode, the `null` is treated as a valid `CompletionStage`, which immediately results in a NPE. That NPE is subsequently caught and transformed into a failed `CompletionStage`, but it's better to not throw it at all.

To be able to do this, the internal SPI `AsyncSupport` gains a new method that is able to create an already complete instance of the async type.