### PR TITLE
make ThreadTimer not singleton again

### DIFF
--- a/doc/modules/ROOT/pages/reference/metrics.adoc
+++ b/doc/modules/ROOT/pages/reference/metrics.adoc
@@ -45,7 +45,8 @@ The behavior of the timer thread can be observed through the following metrics:
 | Type | `Gauge<Integer>`
 | Unit | None
 | Description | The number of tasks that are currently scheduled (for future execution) on the timer.
-| Tags | None
+| Tags
+a| * `id` - the ID of the timer, to distinguish multiple timers in a multi-application environment
 |===
 
 == Micrometer Support

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/Timer.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/Timer.java
@@ -10,6 +10,13 @@ import java.util.concurrent.Executor;
  */
 public interface Timer {
     /**
+     * Returns the ID of this timer. Timer IDs are guaranteed to be unique.
+     *
+     * @return the ID of this timer
+     */
+    int getId();
+
+    /**
      * Schedules the {@code task} to be executed in {@code delayInMillis} on this timer's
      * default {@link Executor}.
      * <p>

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/TimerLogger.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/timer/TimerLogger.java
@@ -14,13 +14,13 @@ import org.jboss.logging.annotations.Transform;
 interface TimerLogger extends BasicLogger {
     TimerLogger LOG = Logger.getMessageLogger(TimerLogger.class, TimerLogger.class.getPackage().getName());
 
-    @Message(id = NONE, value = "Timer created")
+    @Message(id = NONE, value = "Timer %s created")
     @LogMessage(level = Logger.Level.TRACE)
-    void createdTimer();
+    void createdTimer(int id);
 
-    @Message(id = NONE, value = "Timer shut down")
+    @Message(id = NONE, value = "Timer %s shut down")
     @LogMessage(level = Logger.Level.TRACE)
-    void shutdownTimer();
+    void shutdownTimer(int id);
 
     @Message(id = NONE, value = "Scheduled timer task %s to run in %s millis")
     @LogMessage(level = Logger.Level.TRACE)

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/RealWorldCompletionStageTimeoutTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/RealWorldCompletionStageTimeoutTest.java
@@ -54,7 +54,7 @@ public class RealWorldCompletionStageTimeoutTest {
         executor = Executors.newSingleThreadExecutor();
 
         timerExecutor = Executors.newSingleThreadExecutor();
-        timer = ThreadTimer.create(timerExecutor);
+        timer = new ThreadTimer(timerExecutor);
     }
 
     @AfterEach

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/TestTimer.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timeout/TestTimer.java
@@ -30,6 +30,11 @@ public final class TestTimer implements Timer {
     }
 
     @Override
+    public int getId() {
+        return 0;
+    }
+
+    @Override
     public TimerTask schedule(long delayInMillis, Runnable task) {
         if (alreadyUsed.compareAndSet(false, true)) {
             executingThread = new Thread(() -> {

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/TestTimer.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/TestTimer.java
@@ -8,6 +8,11 @@ public class TestTimer implements Timer {
     private final Queue<Task> tasks = new ConcurrentLinkedQueue<>();
 
     @Override
+    public int getId() {
+        return 0;
+    }
+
+    @Override
     public TimerTask schedule(long delayInMillis, Runnable runnable) {
         Task task = new Task(runnable);
         tasks.add(task);

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/ThreadTimerStressTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/ThreadTimerStressTest.java
@@ -35,7 +35,7 @@ public class ThreadTimerStressTest {
     @BeforeEach
     public void setUp() throws InterruptedException {
         executor = Executors.newFixedThreadPool(POOL_SIZE);
-        timer = ThreadTimer.create(executor);
+        timer = new ThreadTimer(executor);
 
         // precreate all threads in the pool
         // if we didn't do this, the first few iterations would be dominated

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/ThreadTimerTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/timer/ThreadTimerTest.java
@@ -22,7 +22,7 @@ public class ThreadTimerTest {
     @BeforeEach
     public void setUp() {
         executor = Executors.newSingleThreadExecutor();
-        timer = ThreadTimer.create(executor);
+        timer = new ThreadTimer(executor);
     }
 
     @AfterEach

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/ExecutorHolder.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/ExecutorHolder.java
@@ -25,7 +25,7 @@ public class ExecutorHolder {
     public ExecutorHolder(AsyncExecutorProvider asyncExecutorProvider) {
         this.asyncExecutor = asyncExecutorProvider.get();
         this.eventLoop = EventLoop.get();
-        this.timer = ThreadTimer.create(asyncExecutor);
+        this.timer = new ThreadTimer(asyncExecutor);
         this.shouldShutdownAsyncExecutor = asyncExecutorProvider instanceof DefaultAsyncExecutorProvider;
     }
 

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/MicroProfileMetricsProvider.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/MicroProfileMetricsProvider.java
@@ -11,6 +11,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
 
 import io.smallrye.faulttolerance.ExecutorHolder;
@@ -42,7 +43,8 @@ public class MicroProfileMetricsProvider implements MetricsProvider {
                 .withName(MetricsConstants.TIMER_SCHEDULED)
                 .withUnit(MetricUnits.NONE)
                 .build();
-        registry.gauge(metadata, executorHolder.getTimer(), Timer::countScheduledTasks);
+        Timer timer = executorHolder.getTimer();
+        registry.gauge(metadata, timer, Timer::countScheduledTasks, new Tag("id", "" + timer.getId()));
     }
 
     @Override

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/MicrometerProvider.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/MicrometerProvider.java
@@ -1,5 +1,6 @@
 package io.smallrye.faulttolerance.metrics;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -10,6 +11,7 @@ import jakarta.inject.Singleton;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.smallrye.faulttolerance.ExecutorHolder;
 import io.smallrye.faulttolerance.core.metrics.MeteredOperation;
 import io.smallrye.faulttolerance.core.metrics.MetricsConstants;
@@ -34,7 +36,9 @@ public class MicrometerProvider implements MetricsProvider {
 
     @PostConstruct
     void init() {
-        registry.gauge(MetricsConstants.TIMER_SCHEDULED, executorHolder.getTimer(), Timer::countScheduledTasks);
+        Timer timer = executorHolder.getTimer();
+        registry.gauge(MetricsConstants.TIMER_SCHEDULED, Collections.singletonList(Tag.of("id", "" + timer.getId())),
+                timer, Timer::countScheduledTasks);
     }
 
     @Override

--- a/implementation/standalone/src/main/java/io/smallrye/faulttolerance/standalone/LazyDependencies.java
+++ b/implementation/standalone/src/main/java/io/smallrye/faulttolerance/standalone/LazyDependencies.java
@@ -22,7 +22,7 @@ final class LazyDependencies implements BuilderLazyDependencies {
         this.executor = config.executor();
         this.metricsAdapter = config.metricsAdapter();
         this.eventLoop = EventLoop.get();
-        this.timer = ThreadTimer.create(executor);
+        this.timer = new ThreadTimer(executor);
     }
 
     @Override

--- a/implementation/standalone/src/main/java/io/smallrye/faulttolerance/standalone/MicrometerAdapter.java
+++ b/implementation/standalone/src/main/java/io/smallrye/faulttolerance/standalone/MicrometerAdapter.java
@@ -1,9 +1,11 @@
 package io.smallrye.faulttolerance.standalone;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.smallrye.faulttolerance.core.metrics.MeteredOperation;
 import io.smallrye.faulttolerance.core.metrics.MetricsConstants;
 import io.smallrye.faulttolerance.core.metrics.MetricsProvider;
@@ -19,7 +21,8 @@ public final class MicrometerAdapter implements MetricsAdapter {
     }
 
     MetricsProvider createMetricsProvider(Timer timer) {
-        registry.gauge(MetricsConstants.TIMER_SCHEDULED, timer, Timer::countScheduledTasks);
+        registry.gauge(MetricsConstants.TIMER_SCHEDULED, Collections.singletonList(Tag.of("id", "" + timer.getId())),
+                timer, Timer::countScheduledTasks);
 
         return new MetricsProvider() {
             private final Map<Object, MetricsRecorder> cache = new ConcurrentHashMap<>();


### PR DESCRIPTION
This is for multi-deployment environments, like WildFly, where multiple applications may exist and each will have its own timer.

Fixes #1047