### PR TITLE
separate metrics of @ApplyFaultTolerance for each method

### DIFF
--- a/api/src/main/java/io/smallrye/faulttolerance/api/ApplyFaultTolerance.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/ApplyFaultTolerance.java
@@ -13,7 +13,7 @@ import io.smallrye.common.annotation.Experimental;
 
 /**
  * A special interceptor binding annotation to apply preconfigured fault tolerance.
- * If {@code @ApplyFaultTolerance("&lt;identifier>")} is present on a business method,
+ * If {@code @ApplyFaultTolerance("<identifier>")} is present on a business method,
  * then a bean of type {@link FaultTolerance} with qualifier
  * {@link io.smallrye.common.annotation.Identifier @Identifier("&lt;identifier>")}
  * must exist. Such bean serves as a preconfigured set of fault tolerance strategies
@@ -42,8 +42,8 @@ import io.smallrye.common.annotation.Experimental;
  * <p>
  * A single preconfigured fault tolerance can even be applied to multiple methods with different
  * return types, as long as the constraint on method asynchrony described above is obeyed. In such
- * case, it is customary to declare the fault tolerance instance as {@code FaultTolerance&lt;Object>}
- * for synchronous methods, {@code FaultTolerance&lt;CompletionStage&lt;Object>>} for asynchronous
+ * case, it is customary to declare the fault tolerance instance as {@code FaultTolerance<Object>}
+ * for synchronous methods, {@code FaultTolerance<CompletionStage<Object>>} for asynchronous
  * methods that return {@code CompletionStage}, and so on. Note that this effectively precludes
  * defining a useful fallback, because fallback can only be defined when the value type is known.
  */

--- a/doc/modules/ROOT/pages/reference/reusable.adoc
+++ b/doc/modules/ROOT/pages/reference/reusable.adoc
@@ -50,3 +50,13 @@ Likewise, it is possible to do this for xref:reference/asynchronous.adoc#async-t
 Note that you can't define a synchronous `FaultTolerance<T>` object and apply it to any asynchronous method.
 Similarly, you can't define an asynchronous `FaultTolerance<CompletionStage<T>>` and apply it to a synchronous method or an asynchronous method with different asynchronous type.
 This limitation will be lifted in the future.
+
+== Metrics
+
+Methods annotated `@ApplyFaultTolerance` gather metrics similarly to methods annotated with {microprofile-fault-tolerance} annotations.
+That is, each method gets its own metrics, with the `method` tag being `<fully qualified class name>.<method name>`.
+
+At the same time, state is still shared.
+All methods annotated `@ApplyFaultTolerance` share the same bulkhead, circuit breaker and/or rate limit.
+
+If the `FaultTolerance` object used for `@ApplyFaultTolerance` is also used xref:reference/programmatic-api.adoc[programmatically], that usage is coalesced in metrics under the description as the `method` tag.

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/LazyFaultTolerance.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/LazyFaultTolerance.java
@@ -5,22 +5,27 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import io.smallrye.faulttolerance.api.FaultTolerance;
+import io.smallrye.faulttolerance.core.metrics.MeteredOperationName;
 
 public final class LazyFaultTolerance<T> implements FaultTolerance<T> {
-    private final Supplier<FaultTolerance<T>> builder;
+    private final Supplier<FaultToleranceImpl<?, ?, T>> builder;
     private final Class<?> asyncType;
 
     private final ReentrantLock lock = new ReentrantLock();
 
-    private volatile FaultTolerance<T> instance;
+    private volatile FaultToleranceImpl<?, ?, T> instance;
 
-    LazyFaultTolerance(Supplier<FaultTolerance<T>> builder, Class<?> asyncType) {
+    LazyFaultTolerance(Supplier<FaultToleranceImpl<?, ?, T>> builder, Class<?> asyncType) {
         this.builder = builder;
         this.asyncType = asyncType;
     }
 
     public Class<?> internalGetAsyncType() {
         return asyncType;
+    }
+
+    public T call(Callable<T> action, MeteredOperationName meteredOperationName) throws Exception {
+        return instance().call(action, meteredOperationName);
     }
 
     @Override
@@ -50,8 +55,8 @@ public final class LazyFaultTolerance<T> implements FaultTolerance<T> {
         return instance().castAsync(asyncType);
     }
 
-    private FaultTolerance<T> instance() {
-        FaultTolerance<T> instance = this.instance;
+    private FaultToleranceImpl<?, ?, T> instance() {
+        FaultToleranceImpl<?, ?, T> instance = this.instance;
         if (instance == null) {
             lock.lock();
             try {

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingCompletionStageMetricsCollector.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingCompletionStageMetricsCollector.java
@@ -1,0 +1,34 @@
+package io.smallrye.faulttolerance.core.metrics;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
+import io.smallrye.faulttolerance.core.InvocationContext;
+
+public class DelegatingCompletionStageMetricsCollector<V> implements FaultToleranceStrategy<CompletionStage<V>> {
+    private final FaultToleranceStrategy<CompletionStage<V>> delegate;
+    private final MetricsProvider provider;
+    private final MeteredOperation originalOperation;
+
+    private final ConcurrentMap<MeteredOperation, CompletionStageMetricsCollector<V>> cache = new ConcurrentHashMap<>();
+
+    public DelegatingCompletionStageMetricsCollector(FaultToleranceStrategy<CompletionStage<V>> delegate,
+            MetricsProvider provider, MeteredOperation originalOperation) {
+        this.delegate = delegate;
+        this.provider = provider;
+        this.originalOperation = originalOperation;
+    }
+
+    @Override
+    public CompletionStage<V> apply(InvocationContext<CompletionStage<V>> ctx) throws Exception {
+        MeteredOperationName name = ctx.get(MeteredOperationName.class);
+        MeteredOperation operation = name != null
+                ? new DelegatingMeteredOperation(originalOperation, name.get())
+                : originalOperation;
+        CompletionStageMetricsCollector<V> delegate = cache.computeIfAbsent(operation,
+                ignored -> new CompletionStageMetricsCollector<>(this.delegate, provider.create(operation), operation));
+        return delegate.apply(ctx);
+    }
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingMeteredOperation.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingMeteredOperation.java
@@ -1,0 +1,56 @@
+package io.smallrye.faulttolerance.core.metrics;
+
+final class DelegatingMeteredOperation implements MeteredOperation {
+    private final MeteredOperation operation;
+    private final String name;
+
+    DelegatingMeteredOperation(MeteredOperation operation, String name) {
+        this.operation = operation;
+        this.name = name;
+    }
+
+    @Override
+    public boolean isAsynchronous() {
+        return operation.isAsynchronous();
+    }
+
+    @Override
+    public boolean hasBulkhead() {
+        return operation.hasBulkhead();
+    }
+
+    @Override
+    public boolean hasCircuitBreaker() {
+        return operation.hasCircuitBreaker();
+    }
+
+    @Override
+    public boolean hasFallback() {
+        return operation.hasFallback();
+    }
+
+    @Override
+    public boolean hasRateLimit() {
+        return operation.hasRateLimit();
+    }
+
+    @Override
+    public boolean hasRetry() {
+        return operation.hasRetry();
+    }
+
+    @Override
+    public boolean hasTimeout() {
+        return operation.hasTimeout();
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Object cacheKey() {
+        return name;
+    }
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingMetricsCollector.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingMetricsCollector.java
@@ -1,0 +1,33 @@
+package io.smallrye.faulttolerance.core.metrics;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
+import io.smallrye.faulttolerance.core.InvocationContext;
+
+public class DelegatingMetricsCollector<V> implements FaultToleranceStrategy<V> {
+    private final FaultToleranceStrategy<V> delegate;
+    private final MetricsProvider provider;
+    private final MeteredOperation originalOperation;
+
+    private final ConcurrentMap<MeteredOperation, MetricsCollector<V>> cache = new ConcurrentHashMap<>();
+
+    public DelegatingMetricsCollector(FaultToleranceStrategy<V> delegate, MetricsProvider provider,
+            MeteredOperation originalOperation) {
+        this.delegate = delegate;
+        this.provider = provider;
+        this.originalOperation = originalOperation;
+    }
+
+    @Override
+    public V apply(InvocationContext<V> ctx) throws Exception {
+        MeteredOperationName name = ctx.get(MeteredOperationName.class);
+        MeteredOperation operation = name != null
+                ? new DelegatingMeteredOperation(originalOperation, name.get())
+                : originalOperation;
+        MetricsCollector<V> delegate = cache.computeIfAbsent(operation,
+                ignored -> new MetricsCollector<>(this.delegate, provider.create(operation), operation));
+        return delegate.apply(ctx);
+    }
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/MeteredOperationName.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/MeteredOperationName.java
@@ -1,0 +1,13 @@
+package io.smallrye.faulttolerance.core.metrics;
+
+public final class MeteredOperationName {
+    private final String name;
+
+    public MeteredOperationName(String name) {
+        this.name = name;
+    }
+
+    public String get() {
+        return name;
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/metrics/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/metrics/MyFaultTolerance.java
@@ -1,0 +1,21 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.metrics;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.FaultTolerance;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final FaultTolerance<CompletionStage<String>> FT = FaultTolerance.<String> createAsync()
+            .withRetry().maxRetries(2).done()
+            .withFallback().handler(() -> completedFuture("fallback")).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/metrics/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/metrics/MyService.java
@@ -1,0 +1,22 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.metrics;
+
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.faulttolerance.api.ApplyFaultTolerance;
+
+@ApplicationScoped
+public class MyService {
+    @ApplyFaultTolerance("my-fault-tolerance")
+    public CompletionStage<String> first() {
+        return failedFuture(new IllegalArgumentException());
+    }
+
+    @ApplyFaultTolerance("my-fault-tolerance")
+    public CompletionStage<String> second() {
+        return failedFuture(new IllegalStateException());
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/metrics/ReuseAsyncCompletionStageMetricsTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/metrics/ReuseAsyncCompletionStageMetricsTest.java
@@ -1,0 +1,60 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncCompletionStageMetricsTest {
+    @Test
+    public void test(MyService service, @RegistryType(type = MetricRegistry.Type.BASE) MetricRegistry metrics)
+            throws ExecutionException, InterruptedException {
+        assertThat(service.first().toCompletableFuture().get()).isEqualTo("fallback");
+        assertThat(service.second().toCompletableFuture().get()).isEqualTo("fallback");
+        assertThat(service.second().toCompletableFuture().get()).isEqualTo("fallback");
+        assertThat(service.second().toCompletableFuture().get()).isEqualTo("fallback");
+
+        // first
+
+        assertThat(metrics.counter("ft.invocations.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.completionstage.metrics.MyService.first"),
+                new Tag("result", "valueReturned"),
+                new Tag("fallback", "applied"))
+                .getCount()).isEqualTo(1);
+
+        assertThat(metrics.counter("ft.retry.retries.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.completionstage.metrics.MyService.first"))
+                .getCount()).isEqualTo(2);
+        assertThat(metrics.counter("ft.retry.calls.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.completionstage.metrics.MyService.first"),
+                new Tag("retried", "true"),
+                new Tag("retryResult", "maxRetriesReached"))
+                .getCount()).isEqualTo(1);
+
+        // second
+
+        assertThat(metrics.counter("ft.invocations.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.completionstage.metrics.MyService.second"),
+                new Tag("result", "valueReturned"),
+                new Tag("fallback", "applied"))
+                .getCount()).isEqualTo(3);
+
+        assertThat(metrics.counter("ft.retry.retries.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.completionstage.metrics.MyService.second"))
+                .getCount()).isEqualTo(6);
+        assertThat(metrics.counter("ft.retry.calls.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.completionstage.metrics.MyService.second"),
+                new Tag("retried", "true"),
+                new Tag("retryResult", "maxRetriesReached"))
+                .getCount()).isEqualTo(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/metrics/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/metrics/MyFaultTolerance.java
@@ -1,0 +1,19 @@
+package io.smallrye.faulttolerance.reuse.async.uni.metrics;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.FaultTolerance;
+import io.smallrye.faulttolerance.mutiny.api.MutinyFaultTolerance;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final FaultTolerance<Uni<String>> FT = MutinyFaultTolerance.<String> create()
+            .withRetry().maxRetries(2).done()
+            .withFallback().handler(() -> Uni.createFrom().item("fallback")).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/metrics/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/metrics/MyService.java
@@ -1,0 +1,19 @@
+package io.smallrye.faulttolerance.reuse.async.uni.metrics;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.faulttolerance.api.ApplyFaultTolerance;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    @ApplyFaultTolerance("my-fault-tolerance")
+    public Uni<String> first() {
+        return Uni.createFrom().failure(new IllegalArgumentException());
+    }
+
+    @ApplyFaultTolerance("my-fault-tolerance")
+    public Uni<String> second() {
+        return Uni.createFrom().failure(new IllegalStateException());
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/metrics/ReuseAsyncUniMetricsTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/metrics/ReuseAsyncUniMetricsTest.java
@@ -1,0 +1,57 @@
+package io.smallrye.faulttolerance.reuse.async.uni.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncUniMetricsTest {
+    @Test
+    public void test(MyService service, @RegistryType(type = MetricRegistry.Type.BASE) MetricRegistry metrics) {
+        assertThat(service.first().await().indefinitely()).isEqualTo("fallback");
+        assertThat(service.second().await().indefinitely()).isEqualTo("fallback");
+        assertThat(service.second().await().indefinitely()).isEqualTo("fallback");
+        assertThat(service.second().await().indefinitely()).isEqualTo("fallback");
+
+        // first
+
+        assertThat(metrics.counter("ft.invocations.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.uni.metrics.MyService.first"),
+                new Tag("result", "valueReturned"),
+                new Tag("fallback", "applied"))
+                .getCount()).isEqualTo(1);
+
+        assertThat(metrics.counter("ft.retry.retries.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.uni.metrics.MyService.first"))
+                .getCount()).isEqualTo(2);
+        assertThat(metrics.counter("ft.retry.calls.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.uni.metrics.MyService.first"),
+                new Tag("retried", "true"),
+                new Tag("retryResult", "maxRetriesReached"))
+                .getCount()).isEqualTo(1);
+
+        // second
+
+        assertThat(metrics.counter("ft.invocations.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.uni.metrics.MyService.second"),
+                new Tag("result", "valueReturned"),
+                new Tag("fallback", "applied"))
+                .getCount()).isEqualTo(3);
+
+        assertThat(metrics.counter("ft.retry.retries.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.uni.metrics.MyService.second"))
+                .getCount()).isEqualTo(6);
+        assertThat(metrics.counter("ft.retry.calls.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.async.uni.metrics.MyService.second"),
+                new Tag("retried", "true"),
+                new Tag("retryResult", "maxRetriesReached"))
+                .getCount()).isEqualTo(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/metrics/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/metrics/MyFaultTolerance.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.reuse.sync.metrics;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.FaultTolerance;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final FaultTolerance<String> FT = FaultTolerance.<String> create()
+            .withRetry().maxRetries(2).done()
+            .withFallback().handler(() -> "fallback").done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/metrics/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/metrics/MyService.java
@@ -1,0 +1,18 @@
+package io.smallrye.faulttolerance.reuse.sync.metrics;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.faulttolerance.api.ApplyFaultTolerance;
+
+@ApplicationScoped
+public class MyService {
+    @ApplyFaultTolerance("my-fault-tolerance")
+    public String first() {
+        throw new IllegalArgumentException();
+    }
+
+    @ApplyFaultTolerance("my-fault-tolerance")
+    public String second() {
+        throw new IllegalStateException();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/metrics/ReuseSyncMetricsTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/metrics/ReuseSyncMetricsTest.java
@@ -1,0 +1,57 @@
+package io.smallrye.faulttolerance.reuse.sync.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseSyncMetricsTest {
+    @Test
+    public void test(MyService service, @RegistryType(type = MetricRegistry.Type.BASE) MetricRegistry metrics) {
+        assertThat(service.first()).isEqualTo("fallback");
+        assertThat(service.second()).isEqualTo("fallback");
+        assertThat(service.second()).isEqualTo("fallback");
+        assertThat(service.second()).isEqualTo("fallback");
+
+        // first
+
+        assertThat(metrics.counter("ft.invocations.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.sync.metrics.MyService.first"),
+                new Tag("result", "valueReturned"),
+                new Tag("fallback", "applied"))
+                .getCount()).isEqualTo(1);
+
+        assertThat(metrics.counter("ft.retry.retries.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.sync.metrics.MyService.first"))
+                .getCount()).isEqualTo(2);
+        assertThat(metrics.counter("ft.retry.calls.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.sync.metrics.MyService.first"),
+                new Tag("retried", "true"),
+                new Tag("retryResult", "maxRetriesReached"))
+                .getCount()).isEqualTo(1);
+
+        // second
+
+        assertThat(metrics.counter("ft.invocations.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.sync.metrics.MyService.second"),
+                new Tag("result", "valueReturned"),
+                new Tag("fallback", "applied"))
+                .getCount()).isEqualTo(3);
+
+        assertThat(metrics.counter("ft.retry.retries.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.sync.metrics.MyService.second"))
+                .getCount()).isEqualTo(6);
+        assertThat(metrics.counter("ft.retry.calls.total",
+                new Tag("method", "io.smallrye.faulttolerance.reuse.sync.metrics.MyService.second"),
+                new Tag("retried", "true"),
+                new Tag("retryResult", "maxRetriesReached"))
+                .getCount()).isEqualTo(3);
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/metrics/MyFaultTolerance.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/metrics/MyFaultTolerance.kt
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.kotlin.reuse.metrics
+
+import io.smallrye.common.annotation.Identifier
+import io.smallrye.faulttolerance.api.FaultTolerance
+import java.util.function.Supplier
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+
+@ApplicationScoped
+object MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    val FT = FaultTolerance.create<String>()
+            .withRetry().maxRetries(2).done()
+            .withFallback().handler(Supplier { "fallback" }).done()
+            .build()
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/metrics/MyService.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/metrics/MyService.kt
@@ -1,0 +1,19 @@
+package io.smallrye.faulttolerance.kotlin.reuse.metrics
+
+import io.smallrye.faulttolerance.api.ApplyFaultTolerance
+import java.lang.IllegalArgumentException
+import java.util.concurrent.atomic.AtomicInteger
+import jakarta.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+open class MyService {
+    @ApplyFaultTolerance("my-fault-tolerance")
+    open fun first(): String {
+        throw IllegalArgumentException()
+    }
+
+    @ApplyFaultTolerance("my-fault-tolerance")
+    open fun second(): String {
+        throw IllegalStateException()
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/metrics/ReuseKotlinMetricsTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/metrics/ReuseKotlinMetricsTest.kt
@@ -1,0 +1,55 @@
+package io.smallrye.faulttolerance.kotlin.reuse.metrics
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.metrics.MetricRegistry
+import org.eclipse.microprofile.metrics.Tag
+import org.eclipse.microprofile.metrics.annotation.RegistryType
+import org.jboss.weld.junit5.auto.AddBeanClasses
+import org.junit.jupiter.api.Test
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance::class)
+class ReuseKotlinMetricsTest {
+    @Test
+    fun test(service: MyService, @RegistryType(type = MetricRegistry.Type.BASE) metrics: MetricRegistry) {
+        assertThat(service.first()).isEqualTo("fallback")
+        assertThat(service.second()).isEqualTo("fallback")
+        assertThat(service.second()).isEqualTo("fallback")
+        assertThat(service.second()).isEqualTo("fallback")
+
+        // first
+
+        assertThat(metrics.counter("ft.invocations.total",
+            Tag("method", "io.smallrye.faulttolerance.kotlin.reuse.metrics.MyService.first"),
+            Tag("result", "valueReturned"),
+            Tag("fallback", "applied")
+        ).count).isEqualTo(1);
+
+        assertThat(metrics.counter("ft.retry.retries.total",
+            Tag("method", "io.smallrye.faulttolerance.kotlin.reuse.metrics.MyService.first"))
+            .count).isEqualTo(2);
+        assertThat(metrics.counter("ft.retry.calls.total",
+            Tag("method", "io.smallrye.faulttolerance.kotlin.reuse.metrics.MyService.first"),
+            Tag("retried", "true"),
+            Tag("retryResult", "maxRetriesReached")
+        ).count).isEqualTo(1);
+
+        // second
+
+        assertThat(metrics.counter("ft.invocations.total",
+            Tag("method", "io.smallrye.faulttolerance.kotlin.reuse.metrics.MyService.second"),
+            Tag("result", "valueReturned"),
+            Tag("fallback", "applied")
+        ).count).isEqualTo(3);
+
+        assertThat(metrics.counter("ft.retry.retries.total",
+            Tag("method", "io.smallrye.faulttolerance.kotlin.reuse.metrics.MyService.second")
+        ).count).isEqualTo(6);
+        assertThat(metrics.counter("ft.retry.calls.total",
+            Tag("method", "io.smallrye.faulttolerance.kotlin.reuse.metrics.MyService.second"),
+            Tag("retried", "true"),
+            Tag("retryResult", "maxRetriesReached")
+        ).count).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
This commit separates metrics of `@ApplyFaultTolerance` methods, so that each method has its own metrics yet they all share the same state.

Fixes #1060