### PR TITLE
add FaultTolerance.BulkheadBuilder.enableVirtualThreadsQueueing()

### DIFF
--- a/api/src/main/java/io/smallrye/faulttolerance/api/FaultTolerance.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/FaultTolerance.java
@@ -410,6 +410,18 @@ public interface FaultTolerance<T> {
             BulkheadBuilder<T, R> queueSize(int value);
 
             /**
+             * Enables bulkhead queueing for synchronous actions executed on virtual threads.
+             * This makes it possible to call {@link #queueSize(int)} even if this builder does
+             * not configure fault tolerance for asynchronous actions.
+             * <p>
+             * If you use this method, you <strong>have to ensure</strong> that the guard
+             * is executed on a virtual thread.
+             *
+             * @return this bulkhead builder
+             */
+            BulkheadBuilder<T, R> enableVirtualThreadsQueueing();
+
+            /**
              * Sets a callback that will be invoked when this bulkhead accepts an invocation.
              * In case of asynchronous actions, accepting into bulkhead doesn't mean the action
              * is immediately invoked; the invocation is first put into a queue and may wait there.

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/bulkhead/FutureThreadPoolBulkhead.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/bulkhead/FutureThreadPoolBulkhead.java
@@ -1,16 +1,8 @@
 package io.smallrye.faulttolerance.core.bulkhead;
 
-import static io.smallrye.faulttolerance.core.bulkhead.BulkheadLogger.LOG;
-
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
-import io.smallrye.faulttolerance.core.InvocationContext;
-import io.smallrye.faulttolerance.core.async.FutureCancellationEvent;
 
 /**
  * Thread pool style bulkhead for {@code Future} asynchronous executions.
@@ -21,92 +13,8 @@ import io.smallrye.faulttolerance.core.async.FutureCancellationEvent;
  * but is the easiest way to implement them for {@code Future}. We do it properly
  * for {@code CompletionStage}, which is much more useful anyway.
  */
-public class FutureThreadPoolBulkhead<V> extends BulkheadBase<Future<V>> {
-    private final int queueSize;
-    private final Semaphore capacitySemaphore;
-    private final Semaphore workSemaphore;
-
+public class FutureThreadPoolBulkhead<V> extends SemaphoreThreadPoolBulkhead<Future<V>> {
     public FutureThreadPoolBulkhead(FaultToleranceStrategy<Future<V>> delegate, String description, int size, int queueSize) {
-        super(description, delegate);
-        this.queueSize = queueSize;
-        this.capacitySemaphore = new Semaphore(size + queueSize, true);
-        this.workSemaphore = new Semaphore(size, true);
-    }
-
-    @Override
-    public Future<V> apply(InvocationContext<Future<V>> ctx) throws Exception {
-        LOG.trace("ThreadPoolBulkhead started");
-        try {
-            return doApply(ctx);
-        } finally {
-            LOG.trace("ThreadPoolBulkhead finished");
-        }
-    }
-
-    private Future<V> doApply(InvocationContext<Future<V>> ctx) throws Exception {
-        if (capacitySemaphore.tryAcquire()) {
-            LOG.trace("Capacity semaphore acquired, accepting task into bulkhead");
-            ctx.fireEvent(BulkheadEvents.DecisionMade.ACCEPTED);
-            ctx.fireEvent(BulkheadEvents.StartedWaiting.INSTANCE);
-
-            AtomicBoolean cancellationInvalid = new AtomicBoolean(false);
-            AtomicBoolean cancelled = new AtomicBoolean(false);
-            AtomicReference<Thread> executingThread = new AtomicReference<>(Thread.currentThread());
-            ctx.registerEventHandler(FutureCancellationEvent.class, event -> {
-                if (cancellationInvalid.get()) {
-                    // in case of retries, multiple handlers of FutureCancellationEvent may be registered,
-                    // need to make sure that a handler belonging to an older bulkhead task doesn't do anything
-                    return;
-                }
-
-                if (LOG.isTraceEnabled()) {
-                    LOG.tracef("Cancelling bulkhead task,%s interrupting executing thread",
-                            (event.interruptible ? "" : " NOT"));
-                }
-                cancelled.set(true);
-                if (event.interruptible) {
-                    executingThread.get().interrupt();
-                }
-            });
-
-            try {
-                workSemaphore.acquire();
-                LOG.trace("Work semaphore acquired, running task");
-            } catch (InterruptedException e) {
-                cancellationInvalid.set(true);
-
-                capacitySemaphore.release();
-                LOG.trace("Capacity semaphore released, task leaving bulkhead");
-                ctx.fireEvent(BulkheadEvents.FinishedWaiting.INSTANCE);
-                throw new CancellationException();
-            }
-
-            ctx.fireEvent(BulkheadEvents.FinishedWaiting.INSTANCE);
-            ctx.fireEvent(BulkheadEvents.StartedRunning.INSTANCE);
-            try {
-                if (cancelled.get()) {
-                    throw new CancellationException();
-                }
-                return delegate.apply(ctx);
-            } finally {
-                cancellationInvalid.set(true);
-
-                workSemaphore.release();
-                LOG.trace("Work semaphore released, task finished");
-                capacitySemaphore.release();
-                LOG.trace("Capacity semaphore released, task leaving bulkhead");
-                ctx.fireEvent(BulkheadEvents.FinishedRunning.INSTANCE);
-            }
-        } else {
-            LOG.debugOrTrace(description + " invocation prevented by bulkhead",
-                    "Capacity semaphore not acquired, rejecting task from bulkhead");
-            ctx.fireEvent(BulkheadEvents.DecisionMade.REJECTED);
-            throw bulkheadRejected();
-        }
-    }
-
-    // only for tests
-    int getQueueSize() {
-        return Math.max(0, queueSize - capacitySemaphore.availablePermits());
+        super(delegate, description, size, queueSize);
     }
 }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/bulkhead/SemaphoreThreadPoolBulkhead.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/bulkhead/SemaphoreThreadPoolBulkhead.java
@@ -1,0 +1,107 @@
+package io.smallrye.faulttolerance.core.bulkhead;
+
+import static io.smallrye.faulttolerance.core.bulkhead.BulkheadLogger.LOG;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
+import io.smallrye.faulttolerance.core.InvocationContext;
+import io.smallrye.faulttolerance.core.async.FutureCancellationEvent;
+
+/**
+ * Assumes that this bulkhead is already executed on an extra thread.
+ * Under that assumption, we don't have to submit tasks to another executor
+ * or use an actual queue. We just limit the task execution by semaphores.
+ */
+public class SemaphoreThreadPoolBulkhead<V> extends BulkheadBase<V> {
+    private final int queueSize;
+    private final Semaphore capacitySemaphore;
+    private final Semaphore workSemaphore;
+
+    public SemaphoreThreadPoolBulkhead(FaultToleranceStrategy<V> delegate, String description, int size, int queueSize) {
+        super(description, delegate);
+        this.queueSize = queueSize;
+        this.capacitySemaphore = new Semaphore(size + queueSize, true);
+        this.workSemaphore = new Semaphore(size, true);
+    }
+
+    @Override
+    public V apply(InvocationContext<V> ctx) throws Exception {
+        LOG.trace("ThreadPoolBulkhead started");
+        try {
+            return doApply(ctx);
+        } finally {
+            LOG.trace("ThreadPoolBulkhead finished");
+        }
+    }
+
+    private V doApply(InvocationContext<V> ctx) throws Exception {
+        if (capacitySemaphore.tryAcquire()) {
+            LOG.trace("Capacity semaphore acquired, accepting task into bulkhead");
+            ctx.fireEvent(BulkheadEvents.DecisionMade.ACCEPTED);
+            ctx.fireEvent(BulkheadEvents.StartedWaiting.INSTANCE);
+
+            AtomicBoolean cancellationInvalid = new AtomicBoolean(false);
+            AtomicBoolean cancelled = new AtomicBoolean(false);
+            AtomicReference<Thread> executingThread = new AtomicReference<>(Thread.currentThread());
+            ctx.registerEventHandler(FutureCancellationEvent.class, event -> {
+                if (cancellationInvalid.get()) {
+                    // in case of retries, multiple handlers of FutureCancellationEvent may be registered,
+                    // need to make sure that a handler belonging to an older bulkhead task doesn't do anything
+                    return;
+                }
+
+                if (LOG.isTraceEnabled()) {
+                    LOG.tracef("Cancelling bulkhead task,%s interrupting executing thread",
+                            (event.interruptible ? "" : " NOT"));
+                }
+                cancelled.set(true);
+                if (event.interruptible) {
+                    executingThread.get().interrupt();
+                }
+            });
+
+            try {
+                workSemaphore.acquire();
+                LOG.trace("Work semaphore acquired, running task");
+            } catch (InterruptedException e) {
+                cancellationInvalid.set(true);
+
+                capacitySemaphore.release();
+                LOG.trace("Capacity semaphore released, task leaving bulkhead");
+                ctx.fireEvent(BulkheadEvents.FinishedWaiting.INSTANCE);
+                throw new CancellationException();
+            }
+
+            ctx.fireEvent(BulkheadEvents.FinishedWaiting.INSTANCE);
+            ctx.fireEvent(BulkheadEvents.StartedRunning.INSTANCE);
+            try {
+                if (cancelled.get()) {
+                    throw new CancellationException();
+                }
+                return delegate.apply(ctx);
+            } finally {
+                cancellationInvalid.set(true);
+
+                workSemaphore.release();
+                LOG.trace("Work semaphore released, task finished");
+                capacitySemaphore.release();
+                LOG.trace("Capacity semaphore released, task leaving bulkhead");
+                ctx.fireEvent(BulkheadEvents.FinishedRunning.INSTANCE);
+            }
+        } else {
+            LOG.debugOrTrace(description + " invocation prevented by bulkhead",
+                    "Capacity semaphore not acquired, rejecting task from bulkhead");
+            ctx.fireEvent(BulkheadEvents.DecisionMade.REJECTED);
+            throw bulkheadRejected();
+        }
+    }
+
+    // only for tests
+    int getQueueSize() {
+        return Math.max(0, queueSize - capacitySemaphore.availablePermits());
+    }
+}


### PR DESCRIPTION
This method enables bulkhead queueing for synchronous actions executed on virtual threads. The implementation is a simple two-semaphores bulkhead, which has in fact already existed as `FutureThreadPoolBulkhead`. This commit generalizes that class and leaves `FutureThreadPoolBulkhead` as a special case, nearly empty, for guarding asynchronous actions returning `Future<V>`.

Fixes #987
Closes #1015