### PR TITLE
enable declarative @Fallback and thread offload with @ApplyGuard

### DIFF
--- a/api/src/main/java/io/smallrye/faulttolerance/api/ApplyGuard.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/ApplyGuard.java
@@ -12,7 +12,7 @@ import jakarta.interceptor.InterceptorBinding;
 import io.smallrye.common.annotation.Experimental;
 
 /**
- * A special interceptor binding annotation to apply preconfigured fault tolerance.
+ * An interceptor binding annotation to apply preconfigured fault tolerance.
  * If {@code @ApplyGuard("<identifier>")} is present on a business method,
  * then a bean of type {@link Guard} or {@link TypedGuard} with qualifier
  * {@link io.smallrye.common.annotation.Identifier @Identifier("&lt;identifier>")}
@@ -30,12 +30,28 @@ import io.smallrye.common.annotation.Experimental;
  * the one on the method takes precedence.
  * <p>
  * When {@code @ApplyGuard} applies to a business method, all other fault tolerance
- * annotations that would otherwise also apply to that method are ignored.
+ * annotations that would also apply to that method are ignored, except:
+ *
+ * <ul>
+ * <li>{@link org.eclipse.microprofile.faulttolerance.Fallback @Fallback}</li>
+ * <li>{@link org.eclipse.microprofile.faulttolerance.Asynchronous @Asynchronous}</li>
+ * <li>{@link AsynchronousNonBlocking @AsynchronousNonBlocking}</li>
+ * </ul>
+ *
+ * If {@code @Fallback} is present, it is used both by {@code Guard} and {@code TypedGuard}
+ * and it overrides the possible fallback configuration of {@code TypedGuard}. Further,
+ * the thread offload configuration of {@code Guard} or {@code TypedGuard} is ignored
+ * if the annotated method is asynchronous as determined from the method signature
+ * and possible annotations ({@code @Asynchronous} and {@code @AsynchronousNonBlocking}).
+ * The thread offload configuration of {@code Guard} or {@code TypedGuard} is only honored
+ * when the method cannot be determined to be asynchronous, but it still declares
+ * an asynchronous return type.
  * <p>
  * A single preconfigured fault tolerance can be applied to multiple methods.
- * If the preconfigured fault tolerance is of type {@code TypedGuard}, then all methods
- * must have the same return type. If the preconfigured fault tolerance is of type {@code Guard},
- * no such requirement applies; note that in this case, there is no way to define a fallback.
+ * If the preconfigured fault tolerance is a {@code TypedGuard}, then all methods
+ * must have the same return type, which must be equal to the type the {@code TypedGuard}
+ * was created with. If the preconfigured fault tolerance is of type {@code Guard},
+ * no such requirement applies.
  * <p>
  * Note that this annotation has the same differences to standard MicroProfile Fault Tolerance
  * as {@code Guard} / {@code TypedGuard}:

--- a/doc/modules/ROOT/pages/reference/programmatic-api.adoc
+++ b/doc/modules/ROOT/pages/reference/programmatic-api.adoc
@@ -266,6 +266,17 @@ In this case, it won't be possible to distinguish the different `Guard` objects 
 
 If no description is provided, a random UUID is used.
 
+== Differences to the Specification
+
+`Guard` and `TypedGuard` have the following differences to standard MicroProfile Fault Tolerance:
+
+* asynchronous actions of type `java.util.concurrent.Future` are not supported;
+* the fallback, circuit breaker and retry strategies always inspect the cause chain of exceptions, following the behavior of SmallRye Fault Tolerance in the non-compatible mode.
+
+== Kotlin `suspend` Functions
+
+The `Guard` and `TypedGuard` APIs do not support Kotlin `suspend` functions at the moment.
+
 == Integration Concerns
 
 Integration concerns, which are particularly interesting for users of the standalone implementation, are xref:integration/programmatic-api.adoc[described] in the integration section.

--- a/doc/modules/ROOT/pages/reference/reusable.adoc
+++ b/doc/modules/ROOT/pages/reference/reusable.adoc
@@ -9,7 +9,7 @@ Each method has its own bulkhead, circuit breaker and/or rate limit, which is of
 The xref:reference/programmatic-api.adoc[programmatic API] of {smallrye-fault-tolerance} allows using a single `Guard` or `TypedGuard` object to guard multiple disparate actions, which allows reuse and state sharing.
 It is possible to use a programmatically constructed `Guard` or `TypedGuard` object declaratively, using the `@ApplyGuard` annotation.
 
-To be able to do that, we need a bean of type `Guard` with the `@Identifier` qualifier:
+To be able to do that, we need a bean of type `Guard` (or `TypedGuard`) with the `@Identifier` qualifier:
 
 [source,java]
 ----
@@ -46,10 +46,40 @@ public class MyService {
 }
 ----
 
-Note that it is not possible to define a fallback on `Guard`, because fallback is tied to the action type.
+== Defining Fallback
 
-It is also possible to create a bean of type `TypedGuard<>` and apply it to methods that return the type `TypedGuard` was created with.
-Note that `TypedGuard` allows defining a fallback, because it can only be used to guard methods with a single return type.
+Note that it is not possible to define a fallback on `Guard`, because fallback is tied to the action type.
+It is possible to define a fallback on `TypedGuard`, because it can only be used to guard methods with a single return type, equal to the type the `TypedGuard` was created with.
+
+However, the `@ApplyGuard` annotation pays attention to the `@Fallback` annotation.
+If `@Fallback` is defined, it is used both by `Guard` and `TypedGuard` instances, and it overrides the possible fallback defined on the `TypedGuard`.
+
+== Defining Thread Offload
+
+Both `Guard` and `TypedGuard` allow enabling or disabling thread offload.
+This is ignored by `@ApplyGuard` if the annotated method is asynchronous as determined from the method signature and possible annotations (`@Asynchronous` and `@AsynchronousNonBlocking`).
+See xref:reference/asynchronous.adoc[] for more information about how that determination works.
+
+The thread offload configuration of `Guard` or `TypedGuard` is only honored when the method cannot be determined to be asynchronous, but it still declares an asynchronous return type.
+
+.Compatible Mode
+****
+In the compatible mode, methods are determined to be asynchronous when they are annotated `@Asynchronous` or `@AsynchronousNonBlocking` and they declare an asynchronous return type.
+For such methods, the `Guard` / `TypedGuard` thread offload configuration does not apply.
+
+For methods that declare an asynchronous return type but are not annotated with `@Asynchronous` or `@AsynchronousNonBlocking`, the configuration on `Guard` / `TypedGuard` is honored.
+****
+
+.Non-compatible Mode
+****
+In the non-compatible mode, methods are determined to be asynchronous whenever they declare an asynchronous return type.
+The `@Asynchronous` and `@AsynchronousNonBlocking` only affect whether the invocation of that method is offloaded to an extra thread.
+If none of these annotations is present, no thread offload happens.
+
+In other words, in non-compatible mode, the `Guard` / `TypedGuard` thread offload configuration never applies.
+
+See xref:reference/non-compat.adoc[] for more information about the non-compatible mode.
+****
 
 == Metrics
 
@@ -60,6 +90,17 @@ At the same time, state is still shared.
 All methods annotated `@ApplyGuard` share the same bulkhead, circuit breaker and/or rate limit.
 
 If the `Guard` or `TypedGuard` object used for `@ApplyGuard` is also used xref:reference/programmatic-api.adoc[programmatically], that usage is coalesced in metrics under the description as the `method` tag.
+
+== Differences to the Specification
+
+`@ApplyGuard` has the same differences to standard MicroProfile Fault Tolerance as `Guard` / `TypedGuard`:
+
+* asynchronous actions of type `java.util.concurrent.Future` are not supported;
+* the fallback, circuit breaker and retry strategies always inspect the cause chain of exceptions, following the behavior of SmallRye Fault Tolerance in the non-compatible mode.
+
+== Kotlin `suspend` Functions
+
+The `@ApplyGuard` API does not support Kotlin `suspend` functions at the moment.
 
 [[migration_from_applyfaulttolerance]]
 == Migration from `@ApplyFaultTolerance`

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
@@ -21,7 +21,6 @@ import io.smallrye.faulttolerance.api.CircuitBreakerState;
 import io.smallrye.faulttolerance.api.CustomBackoffStrategy;
 import io.smallrye.faulttolerance.api.FaultTolerance;
 import io.smallrye.faulttolerance.api.RateLimitType;
-import io.smallrye.faulttolerance.core.FailureContext;
 import io.smallrye.faulttolerance.core.FaultToleranceContext;
 import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
 import io.smallrye.faulttolerance.core.Future;
@@ -31,6 +30,7 @@ import io.smallrye.faulttolerance.core.bulkhead.Bulkhead;
 import io.smallrye.faulttolerance.core.circuit.breaker.CircuitBreaker;
 import io.smallrye.faulttolerance.core.circuit.breaker.CircuitBreakerEvents;
 import io.smallrye.faulttolerance.core.fallback.Fallback;
+import io.smallrye.faulttolerance.core.fallback.FallbackFunction;
 import io.smallrye.faulttolerance.core.invocation.AsyncSupport;
 import io.smallrye.faulttolerance.core.invocation.AsyncSupportRegistry;
 import io.smallrye.faulttolerance.core.invocation.ConstantInvoker;
@@ -364,7 +364,7 @@ public final class FaultToleranceImpl<V, T> implements FaultTolerance<T> {
 
             // fallback is always enabled
             if (fallbackBuilder != null) {
-                Function<FailureContext, Future<T>> fallbackFunction = ctx -> {
+                FallbackFunction<T> fallbackFunction = ctx -> {
                     return Future.from(() -> fallbackBuilder.handler.apply(ctx.failure));
                 };
                 result = new Fallback<>(result, description, fallbackFunction,
@@ -449,7 +449,7 @@ public final class FaultToleranceImpl<V, T> implements FaultTolerance<T> {
                     throw new FaultToleranceException("Unknown async type: " + asyncType);
                 }
 
-                Function<FailureContext, Future<V>> fallbackFunction = ctx -> {
+                FallbackFunction<V> fallbackFunction = ctx -> {
                     try {
                         return asyncSupport.toFuture(ConstantInvoker.of(
                                 fallbackBuilder.handler.apply(ctx.failure)));

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/ThreadOffloadEnabled.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/async/ThreadOffloadEnabled.java
@@ -1,0 +1,9 @@
+package io.smallrye.faulttolerance.core.async;
+
+public final class ThreadOffloadEnabled {
+    public final boolean value;
+
+    public ThreadOffloadEnabled(boolean value) {
+        this.value = value;
+    }
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/fallback/FallbackFunction.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/fallback/FallbackFunction.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.core.fallback;
+
+import java.util.function.Function;
+
+import io.smallrye.faulttolerance.core.FailureContext;
+import io.smallrye.faulttolerance.core.Future;
+
+@FunctionalInterface
+public interface FallbackFunction<T> extends Function<FailureContext, Future<T>> {
+    FallbackFunction<?> IGNORE = ignored -> {
+        throw new UnsupportedOperationException();
+    };
+
+    static <T> FallbackFunction<T> ignore() {
+        return (FallbackFunction<T>) IGNORE;
+    }
+}

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/fallback/ThreadOffloadFallbackFunction.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/fallback/ThreadOffloadFallbackFunction.java
@@ -7,7 +7,7 @@ import io.smallrye.faulttolerance.core.Completer;
 import io.smallrye.faulttolerance.core.FailureContext;
 import io.smallrye.faulttolerance.core.Future;
 
-public final class ThreadOffloadFallbackFunction<T> implements Function<FailureContext, Future<T>> {
+public final class ThreadOffloadFallbackFunction<T> implements FallbackFunction<T> {
     private final Function<FailureContext, Future<T>> delegate;
     private final Executor executor;
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/util/ExceptionDecision.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/util/ExceptionDecision.java
@@ -5,4 +5,8 @@ public interface ExceptionDecision {
 
     ExceptionDecision ALWAYS_EXPECTED = ignored -> true;
     ExceptionDecision ALWAYS_FAILURE = ignored -> false;
+
+    ExceptionDecision IGNORE = ignored -> {
+        throw new UnsupportedOperationException();
+    };
 }

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/fallback/FallbackSyncTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/fallback/FallbackSyncTest.java
@@ -5,11 +5,8 @@ import static io.smallrye.faulttolerance.core.util.TestThread.runOnTestThread;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.function.Function;
-
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.faulttolerance.core.FailureContext;
 import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
 import io.smallrye.faulttolerance.core.Future;
 import io.smallrye.faulttolerance.core.util.ExceptionDecision;
@@ -117,7 +114,7 @@ public class FallbackSyncTest {
     public void waitingOnParty_interruptedInFallback() throws InterruptedException {
         TestInvocation<String> invocation = TestInvocation.of(TestException::doThrow);
         Party party = Party.create(1);
-        Function<FailureContext, Future<String>> fallbackFunction = ctx -> {
+        FallbackFunction<String> fallbackFunction = ctx -> {
             try {
                 party.participant().attend();
                 return Future.of("fallback");
@@ -160,7 +157,7 @@ public class FallbackSyncTest {
     @Test
     public void selfInterruptedInFallback_value() throws Exception {
         TestInvocation<String> invocation = TestInvocation.of(TestException::doThrow);
-        Function<FailureContext, Future<String>> fallbackFunction = ctx -> {
+        FallbackFunction<String> fallbackFunction = ctx -> {
             Thread.currentThread().interrupt();
             return Future.of("fallback");
         };
@@ -173,7 +170,7 @@ public class FallbackSyncTest {
     @Test
     public void selfInterruptedInFallback_exception() {
         TestInvocation<String> invocation = TestInvocation.of(TestException::doThrow);
-        Function<FailureContext, Future<String>> fallbackFunction = ctx -> {
+        FallbackFunction<String> fallbackFunction = ctx -> {
             Thread.currentThread().interrupt();
             throw new RuntimeException();
         };

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/internal/StrategyCache.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/internal/StrategyCache.java
@@ -10,8 +10,10 @@ import jakarta.inject.Singleton;
 import io.smallrye.faulttolerance.SpecCompatibility;
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 import io.smallrye.faulttolerance.core.FaultToleranceStrategy;
+import io.smallrye.faulttolerance.core.fallback.FallbackFunction;
 import io.smallrye.faulttolerance.core.invocation.AsyncSupport;
 import io.smallrye.faulttolerance.core.invocation.AsyncSupportRegistry;
+import io.smallrye.faulttolerance.core.util.ExceptionDecision;
 
 @Singleton
 public class StrategyCache {
@@ -19,6 +21,8 @@ public class StrategyCache {
     private final Map<InterceptionPoint, FallbackMethodCandidates> fallbackMethods = new ConcurrentHashMap<>();
     private final Map<InterceptionPoint, BeforeRetryMethod> beforeRetryMethods = new ConcurrentHashMap<>();
     private final Map<InterceptionPoint, AsyncSupport<?, ?>> asyncSupports = new ConcurrentHashMap<>();
+    private final Map<InterceptionPoint, FallbackFunction<?>> fallbackFunctions = new ConcurrentHashMap<>();
+    private final Map<InterceptionPoint, ExceptionDecision> fallbackExceptionDecisions = new ConcurrentHashMap<>();
 
     private final SpecCompatibility specCompatibility;
 
@@ -28,8 +32,7 @@ public class StrategyCache {
     }
 
     @SuppressWarnings("unchecked")
-    public <V> FaultToleranceStrategy<V> getStrategy(InterceptionPoint point,
-            Supplier<FaultToleranceStrategy<V>> producer) {
+    public <V> FaultToleranceStrategy<V> getStrategy(InterceptionPoint point, Supplier<FaultToleranceStrategy<V>> producer) {
         return (FaultToleranceStrategy<V>) strategies.computeIfAbsent(point, ignored -> producer.get());
     }
 
@@ -43,7 +46,18 @@ public class StrategyCache {
     }
 
     public <V, AT> AsyncSupport<V, AT> getAsyncSupport(InterceptionPoint point, FaultToleranceOperation operation) {
-        return (AsyncSupport<V, AT>) asyncSupports.computeIfAbsent(point,
+        AsyncSupport<?, ?> asyncSupport = asyncSupports.computeIfAbsent(point,
                 ignored -> AsyncSupportRegistry.get(operation.getParameterTypes(), operation.getReturnType()));
+        return (AsyncSupport<V, AT>) asyncSupport;
+    }
+
+    // only used with `@ApplyGuard`, useless otherwise
+    public <V> FallbackFunction<V> getFallbackFunction(InterceptionPoint point, Supplier<FallbackFunction<V>> producer) {
+        return (FallbackFunction<V>) fallbackFunctions.computeIfAbsent(point, ignored -> producer.get());
+    }
+
+    // only used with `@ApplyGuard`, useless otherwise
+    public ExceptionDecision getFallbackExceptionDecision(InterceptionPoint point, Supplier<ExceptionDecision> producer) {
+        return fallbackExceptionDecisions.computeIfAbsent(point, ignored -> producer.get());
     }
 }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/guard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/guard/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.fallback.guard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withRetry().maxRetries(2).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/guard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/guard/MyService.java
@@ -1,0 +1,29 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.fallback.guard;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "fallback")
+    public CompletionStage<String> hello() {
+        COUNTER.incrementAndGet();
+        return failedFuture(new IllegalArgumentException());
+    }
+
+    CompletionStage<String> fallback() {
+        return completedFuture("better fallback");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/guard/ReuseAsyncCompletionStageFallbackGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/guard/ReuseAsyncCompletionStageFallbackGuardTest.java
@@ -1,0 +1,22 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.fallback.guard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncCompletionStageFallbackGuardTest {
+    @Test
+    public void test(MyService service) {
+        assertThat(service.hello())
+                .succeedsWithin(1, TimeUnit.SECONDS)
+                .isEqualTo("better fallback");
+        assertThat(MyService.COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/typedguard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/typedguard/MyFaultTolerance.java
@@ -1,0 +1,22 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.fallback.typedguard;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.Types;
+import io.smallrye.faulttolerance.api.TypedGuard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final TypedGuard<CompletionStage<String>> GUARD = TypedGuard.create(Types.CS_STRING)
+            .withRetry().maxRetries(2).done()
+            .withFallback().handler(() -> completedFuture("fallback")).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/typedguard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/typedguard/MyService.java
@@ -1,0 +1,29 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.fallback.typedguard;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "fallback")
+    public CompletionStage<String> hello() {
+        COUNTER.incrementAndGet();
+        return failedFuture(new IllegalArgumentException());
+    }
+
+    CompletionStage<String> fallback() {
+        return completedFuture("better fallback");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/typedguard/ReuseAsyncCompletionStageFallbackTypedGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/fallback/typedguard/ReuseAsyncCompletionStageFallbackTypedGuardTest.java
@@ -1,0 +1,22 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.fallback.typedguard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncCompletionStageFallbackTypedGuardTest {
+    @Test
+    public void test(MyService service) {
+        assertThat(service.hello())
+                .succeedsWithin(1, TimeUnit.SECONDS)
+                .isEqualTo("better fallback");
+        assertThat(MyService.COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/guard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/guard/MyFaultTolerance.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.threadoffload.guard;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@Singleton
+public class MyFaultTolerance {
+    // not `static` to create a new instance for each Weld container in the test
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public final Guard GUARD = Guard.create()
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/guard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/guard/MyService.java
@@ -1,0 +1,40 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.threadoffload.guard;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_NONBLOCKING = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public CompletionStage<String> hello() {
+        CURRENT_THREAD.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public CompletionStage<String> helloBlocking() {
+        CURRENT_THREAD_BLOCKING.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public CompletionStage<String> helloNonBlocking() {
+        CURRENT_THREAD_NONBLOCKING.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/guard/ReuseAsyncCompletionStageThreadOffloadGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/guard/ReuseAsyncCompletionStageThreadOffloadGuardTest.java
@@ -1,0 +1,52 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.threadoffload.guard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncCompletionStageThreadOffloadGuardTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        testCompatible(service);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
+    public void testCompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_NONBLOCKING).hasValue(currentThread);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+    public void testNoncompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).hasValue(currentThread);
+
+        assertThat(service.helloBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_NONBLOCKING).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/typedguard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/typedguard/MyFaultTolerance.java
@@ -1,0 +1,20 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.threadoffload.typedguard;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.Types;
+import io.smallrye.faulttolerance.api.TypedGuard;
+
+@Singleton
+public class MyFaultTolerance {
+    // not `static` to create a new instance for each Weld container in the test
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public final TypedGuard<CompletionStage<String>> GUARD = TypedGuard.create(Types.CS_STRING)
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/typedguard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/typedguard/MyService.java
@@ -1,0 +1,40 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.threadoffload.typedguard;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_NONBLOCKING = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public CompletionStage<String> hello() {
+        CURRENT_THREAD.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public CompletionStage<String> helloBlocking() {
+        CURRENT_THREAD_BLOCKING.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public CompletionStage<String> helloNonBlocking() {
+        CURRENT_THREAD_NONBLOCKING.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/typedguard/ReuseAsyncCompletionStageThreadOffloadTypedGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/completionstage/threadoffload/typedguard/ReuseAsyncCompletionStageThreadOffloadTypedGuardTest.java
@@ -1,0 +1,52 @@
+package io.smallrye.faulttolerance.reuse.async.completionstage.threadoffload.typedguard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncCompletionStageThreadOffloadTypedGuardTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        testCompatible(service);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
+    public void testCompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_NONBLOCKING).hasValue(currentThread);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+    public void testNoncompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).hasValue(currentThread);
+
+        assertThat(service.helloBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_NONBLOCKING).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/guard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/guard/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.async.uni.fallback.guard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withRetry().maxRetries(2).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/guard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/guard/MyService.java
@@ -1,0 +1,26 @@
+package io.smallrye.faulttolerance.reuse.async.uni.fallback.guard;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "fallback")
+    public Uni<String> hello() {
+        COUNTER.incrementAndGet();
+        return Uni.createFrom().failure(new IllegalArgumentException());
+    }
+
+    Uni<String> fallback() {
+        return Uni.createFrom().item("better fallback");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/guard/ReuseAsyncUniFallbackGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/guard/ReuseAsyncUniFallbackGuardTest.java
@@ -1,0 +1,20 @@
+package io.smallrye.faulttolerance.reuse.async.uni.fallback.guard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncUniFallbackGuardTest {
+    @Test
+    public void test(MyService service) {
+        assertThat(service.hello().await().atMost(Duration.ofSeconds(1))).isEqualTo("better fallback");
+        assertThat(MyService.COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/typedguard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/typedguard/MyFaultTolerance.java
@@ -1,0 +1,19 @@
+package io.smallrye.faulttolerance.reuse.async.uni.fallback.typedguard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.Types;
+import io.smallrye.faulttolerance.api.TypedGuard;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final TypedGuard<Uni<String>> GUARD = TypedGuard.create(Types.UNI_STRING)
+            .withRetry().maxRetries(2).done()
+            .withFallback().handler(() -> Uni.createFrom().item("fallback")).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/typedguard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/typedguard/MyService.java
@@ -1,0 +1,26 @@
+package io.smallrye.faulttolerance.reuse.async.uni.fallback.typedguard;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "fallback")
+    public Uni<String> hello() {
+        COUNTER.incrementAndGet();
+        return Uni.createFrom().failure(new IllegalArgumentException());
+    }
+
+    Uni<String> fallback() {
+        return Uni.createFrom().item("better fallback");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/typedguard/ReuseAsyncUniFallbackTypedGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/fallback/typedguard/ReuseAsyncUniFallbackTypedGuardTest.java
@@ -1,0 +1,20 @@
+package io.smallrye.faulttolerance.reuse.async.uni.fallback.typedguard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncUniFallbackTypedGuardTest {
+    @Test
+    public void test(MyService service) {
+        assertThat(service.hello().await().atMost(Duration.ofSeconds(1))).isEqualTo("better fallback");
+        assertThat(MyService.COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/guard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/guard/MyFaultTolerance.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.reuse.async.uni.threadoffload.guard;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@Singleton
+public class MyFaultTolerance {
+    // not `static` to create a new instance for each Weld container in the test
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public final Guard GUARD = Guard.create()
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/guard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/guard/MyService.java
@@ -1,0 +1,38 @@
+package io.smallrye.faulttolerance.reuse.async.uni.threadoffload.guard;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_NONBLOCKING = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public Uni<String> hello() {
+        CURRENT_THREAD.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public Uni<String> helloBlocking() {
+        CURRENT_THREAD_BLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public Uni<String> helloNonBlocking() {
+        CURRENT_THREAD_NONBLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/guard/ReuseAsyncUniThreadOffloadGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/guard/ReuseAsyncUniThreadOffloadGuardTest.java
@@ -1,0 +1,52 @@
+package io.smallrye.faulttolerance.reuse.async.uni.threadoffload.guard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncUniThreadOffloadGuardTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        testCompatible(service);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
+    public void testCompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.hello().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_NONBLOCKING).hasValue(currentThread);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+    public void testNoncompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.hello().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).hasValue(currentThread);
+
+        assertThat(service.helloBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_NONBLOCKING).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/typedguard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/typedguard/MyFaultTolerance.java
@@ -1,0 +1,19 @@
+package io.smallrye.faulttolerance.reuse.async.uni.threadoffload.typedguard;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.Types;
+import io.smallrye.faulttolerance.api.TypedGuard;
+import io.smallrye.mutiny.Uni;
+
+@Singleton
+public class MyFaultTolerance {
+    // not `static` to create a new instance for each Weld container in the test
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public final TypedGuard<Uni<String>> GUARD = TypedGuard.create(Types.UNI_STRING)
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/typedguard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/typedguard/MyService.java
@@ -1,0 +1,38 @@
+package io.smallrye.faulttolerance.reuse.async.uni.threadoffload.typedguard;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_NONBLOCKING = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public Uni<String> hello() {
+        CURRENT_THREAD.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public Uni<String> helloBlocking() {
+        CURRENT_THREAD_BLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public Uni<String> helloNonBlocking() {
+        CURRENT_THREAD_NONBLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/typedguard/ReuseAsyncUniThreadOffloadTypedGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/async/uni/threadoffload/typedguard/ReuseAsyncUniThreadOffloadTypedGuardTest.java
@@ -1,0 +1,52 @@
+package io.smallrye.faulttolerance.reuse.async.uni.threadoffload.typedguard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseAsyncUniThreadOffloadTypedGuardTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        testCompatible(service);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
+    public void testCompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.hello().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_NONBLOCKING).hasValue(currentThread);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+    public void testNoncompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.hello().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).hasValue(currentThread);
+
+        assertThat(service.helloBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_NONBLOCKING).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/all/fallback/MixedReuseAllFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/all/fallback/MixedReuseAllFallbackTest.java
@@ -1,0 +1,26 @@
+package io.smallrye.faulttolerance.reuse.mixed.all.fallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseAllFallbackTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        assertThat(service.hello()).isEqualTo("hello");
+        assertThat(MyService.STRING_COUNTER).hasValue(3);
+
+        assertThat(service.theAnswer().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.INT_COUNTER).hasValue(3);
+
+        assertThat(service.badNumber().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(13L);
+        assertThat(MyService.LONG_COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/all/fallback/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/all/fallback/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.mixed.all.fallback;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withRetry().maxRetries(2).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/all/fallback/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/all/fallback/MyService.java
@@ -1,0 +1,54 @@
+package io.smallrye.faulttolerance.reuse.mixed.all.fallback;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger STRING_COUNTER = new AtomicInteger(0);
+    static final AtomicInteger INT_COUNTER = new AtomicInteger(0);
+    static final AtomicInteger LONG_COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "helloFallback")
+    public String hello() {
+        STRING_COUNTER.incrementAndGet();
+        throw new IllegalArgumentException();
+    }
+
+    String helloFallback() {
+        return "hello";
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "theAnswerFallback")
+    public CompletionStage<Integer> theAnswer() {
+        INT_COUNTER.incrementAndGet();
+        return failedFuture(new IllegalArgumentException());
+    }
+
+    CompletionStage<Integer> theAnswerFallback() {
+        return completedFuture(42);
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "badNumberFallback")
+    public Uni<Long> badNumber() {
+        LONG_COUNTER.incrementAndGet();
+        return Uni.createFrom().failure(new IllegalArgumentException());
+    }
+
+    Uni<Long> badNumberFallback() {
+        return Uni.createFrom().item(13L);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/fallback/MixedReuseAsyncBothFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/fallback/MixedReuseAsyncBothFallbackTest.java
@@ -1,0 +1,23 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.both.fallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseAsyncBothFallbackTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.STRING_COUNTER).hasValue(3);
+
+        assertThat(service.theAnswer().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.INT_COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/fallback/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/fallback/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.both.fallback;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withRetry().maxRetries(2).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/fallback/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/fallback/MyService.java
@@ -1,0 +1,42 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.both.fallback;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger STRING_COUNTER = new AtomicInteger(0);
+    static final AtomicInteger INT_COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "helloFallback")
+    public CompletionStage<String> hello() {
+        STRING_COUNTER.incrementAndGet();
+        return failedFuture(new IllegalArgumentException());
+    }
+
+    CompletionStage<String> helloFallback() {
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "theAnswerFallback")
+    public Uni<Integer> theAnswer() {
+        INT_COUNTER.incrementAndGet();
+        return Uni.createFrom().failure(new IllegalArgumentException());
+    }
+
+    Uni<Integer> theAnswerFallback() {
+        return Uni.createFrom().item(42);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/threadoffload/MixedReuseAsyncBothThreadOffloadTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/threadoffload/MixedReuseAsyncBothThreadOffloadTest.java
@@ -1,0 +1,72 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.both.threadoffload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseAsyncBothThreadOffloadTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        testCompatible(service);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
+    public void testCompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_NONBLOCKING).hasValue(currentThread);
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.theAnswer().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_NONBLOCKING).hasValue(currentThread);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+    public void testNoncompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO).hasValue(currentThread);
+
+        assertThat(service.helloBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_NONBLOCKING).hasValue(currentThread);
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.theAnswer().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER).hasValue(currentThread);
+
+        assertThat(service.theAnswerBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_NONBLOCKING).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/threadoffload/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/threadoffload/MyFaultTolerance.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.both.threadoffload;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@Singleton
+public class MyFaultTolerance {
+    // not `static` to create a new instance for each Weld container in the test
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public final Guard GUARD = Guard.create()
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/threadoffload/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/both/threadoffload/MyService.java
@@ -1,0 +1,64 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.both.threadoffload;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO_NONBLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER_NONBLOCKING = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public CompletionStage<String> hello() {
+        CURRENT_THREAD_HELLO.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public CompletionStage<String> helloBlocking() {
+        CURRENT_THREAD_HELLO_BLOCKING.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public CompletionStage<String> helloNonBlocking() {
+        CURRENT_THREAD_HELLO_NONBLOCKING.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    public Uni<Integer> theAnswer() {
+        CURRENT_THREAD_THEANSWER.set(Thread.currentThread());
+        return Uni.createFrom().item(42);
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public Uni<Integer> theAnswerBlocking() {
+        CURRENT_THREAD_THEANSWER_BLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item(42);
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public Uni<Integer> theAnswerNonBlocking() {
+        CURRENT_THREAD_THEANSWER_NONBLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item(42);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/fallback/MixedReuseAsyncCompletionStageFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/fallback/MixedReuseAsyncCompletionStageFallbackTest.java
@@ -1,0 +1,23 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.completionstage.fallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseAsyncCompletionStageFallbackTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.STRING_COUNTER).hasValue(3);
+
+        assertThat(service.theAnswer().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.INT_COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/fallback/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/fallback/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.completionstage.fallback;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withRetry().maxRetries(2).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/fallback/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/fallback/MyService.java
@@ -1,0 +1,41 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.completionstage.fallback;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger STRING_COUNTER = new AtomicInteger(0);
+    static final AtomicInteger INT_COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "helloFallback")
+    public CompletionStage<String> hello() {
+        STRING_COUNTER.incrementAndGet();
+        return failedFuture(new IllegalArgumentException());
+    }
+
+    CompletionStage<String> helloFallback() {
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "theAnswerFallback")
+    public CompletionStage<Integer> theAnswer() {
+        INT_COUNTER.incrementAndGet();
+        return failedFuture(new IllegalArgumentException());
+    }
+
+    CompletionStage<Integer> theAnswerFallback() {
+        return completedFuture(42);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/threadoffload/MixedReuseAsyncCompletionStageThreadOffloadTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/threadoffload/MixedReuseAsyncCompletionStageThreadOffloadTest.java
@@ -1,0 +1,72 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.completionstage.threadoffload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseAsyncCompletionStageThreadOffloadTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        testCompatible(service);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
+    public void testCompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_NONBLOCKING).hasValue(currentThread);
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.theAnswer().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerBlocking().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerNonBlocking().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_NONBLOCKING).hasValue(currentThread);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+    public void testNoncompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.hello().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO).hasValue(currentThread);
+
+        assertThat(service.helloBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_NONBLOCKING).hasValue(currentThread);
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.theAnswer().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER).hasValue(currentThread);
+
+        assertThat(service.theAnswerBlocking().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerNonBlocking().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_NONBLOCKING).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/threadoffload/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/threadoffload/MyFaultTolerance.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.completionstage.threadoffload;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@Singleton
+public class MyFaultTolerance {
+    // not `static` to create a new instance for each Weld container in the test
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public final Guard GUARD = Guard.create()
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/threadoffload/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/completionstage/threadoffload/MyService.java
@@ -1,0 +1,63 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.completionstage.threadoffload;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO_NONBLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER_NONBLOCKING = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public CompletionStage<String> hello() {
+        CURRENT_THREAD_HELLO.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public CompletionStage<String> helloBlocking() {
+        CURRENT_THREAD_HELLO_BLOCKING.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public CompletionStage<String> helloNonBlocking() {
+        CURRENT_THREAD_HELLO_NONBLOCKING.set(Thread.currentThread());
+        return completedFuture("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    public CompletionStage<Integer> theAnswer() {
+        CURRENT_THREAD_THEANSWER.set(Thread.currentThread());
+        return completedFuture(42);
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public CompletionStage<Integer> theAnswerBlocking() {
+        CURRENT_THREAD_THEANSWER_BLOCKING.set(Thread.currentThread());
+        return completedFuture(42);
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public CompletionStage<Integer> theAnswerNonBlocking() {
+        CURRENT_THREAD_THEANSWER_NONBLOCKING.set(Thread.currentThread());
+        return completedFuture(42);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/fallback/MixedReuseAsyncUniFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/fallback/MixedReuseAsyncUniFallbackTest.java
@@ -1,0 +1,23 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.uni.fallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseAsyncUniFallbackTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        assertThat(service.hello().await().indefinitely()).isEqualTo("hello");
+        assertThat(MyService.STRING_COUNTER).hasValue(3);
+
+        assertThat(service.theAnswer().await().indefinitely()).isEqualTo(42);
+        assertThat(MyService.INT_COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/fallback/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/fallback/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.uni.fallback;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withRetry().maxRetries(2).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/fallback/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/fallback/MyService.java
@@ -1,0 +1,38 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.uni.fallback;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger STRING_COUNTER = new AtomicInteger(0);
+    static final AtomicInteger INT_COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "helloFallback")
+    public Uni<String> hello() {
+        STRING_COUNTER.incrementAndGet();
+        return Uni.createFrom().failure(new IllegalArgumentException());
+    }
+
+    Uni<String> helloFallback() {
+        return Uni.createFrom().item("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "theAnswerFallback")
+    public Uni<Integer> theAnswer() {
+        INT_COUNTER.incrementAndGet();
+        return Uni.createFrom().failure(new IllegalArgumentException());
+    }
+
+    Uni<Integer> theAnswerFallback() {
+        return Uni.createFrom().item(42);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/threadoffload/MixedReuseAsyncUniThreadOffloadTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/threadoffload/MixedReuseAsyncUniThreadOffloadTest.java
@@ -1,0 +1,72 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.uni.threadoffload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+import io.smallrye.faulttolerance.util.WithSystemProperty;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseAsyncUniThreadOffloadTest {
+    @Test
+    public void test(MyService service) throws ExecutionException, InterruptedException {
+        testCompatible(service);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "true")
+    public void testCompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.hello().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_NONBLOCKING).hasValue(currentThread);
+
+        // not truly async per `SpecCompatibility`, so thread offload happens per the `Guard` config
+        assertThat(service.theAnswer().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_NONBLOCKING).hasValue(currentThread);
+    }
+
+    @Test
+    @WithSystemProperty(key = "smallrye.faulttolerance.mp-compatibility", value = "false")
+    public void testNoncompatible(MyService service) throws ExecutionException, InterruptedException {
+        Thread currentThread = Thread.currentThread();
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.hello().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO).hasValue(currentThread);
+
+        assertThat(service.helloBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.helloNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_HELLO_NONBLOCKING).hasValue(currentThread);
+
+        // truly async per `SpecCompatibility` and non-blocking by absence of annotation, no thread offload
+        assertThat(service.theAnswer().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER).hasValue(currentThread);
+
+        assertThat(service.theAnswerBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_BLOCKING).doesNotHaveValue(currentThread);
+
+        assertThat(service.theAnswerNonBlocking().subscribeAsCompletionStage().toCompletableFuture().get()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_THEANSWER_NONBLOCKING).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/threadoffload/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/threadoffload/MyFaultTolerance.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.uni.threadoffload;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@Singleton
+public class MyFaultTolerance {
+    // not `static` to create a new instance for each Weld container in the test
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public final Guard GUARD = Guard.create()
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/threadoffload/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/async/uni/threadoffload/MyService.java
@@ -1,0 +1,61 @@
+package io.smallrye.faulttolerance.reuse.mixed.async.uni.threadoffload;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_HELLO_NONBLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER_BLOCKING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_THEANSWER_NONBLOCKING = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public Uni<String> hello() {
+        CURRENT_THREAD_HELLO.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public Uni<String> helloBlocking() {
+        CURRENT_THREAD_HELLO_BLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public Uni<String> helloNonBlocking() {
+        CURRENT_THREAD_HELLO_NONBLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item("hello");
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    public Uni<Integer> theAnswer() {
+        CURRENT_THREAD_THEANSWER.set(Thread.currentThread());
+        return Uni.createFrom().item(42);
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Asynchronous
+    public Uni<Integer> theAnswerBlocking() {
+        CURRENT_THREAD_THEANSWER_BLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item(42);
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @AsynchronousNonBlocking
+    public Uni<Integer> theAnswerNonBlocking() {
+        CURRENT_THREAD_THEANSWER_NONBLOCKING.set(Thread.currentThread());
+        return Uni.createFrom().item(42);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/fallback/MixedReuseSyncFallbackTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/fallback/MixedReuseSyncFallbackTest.java
@@ -1,0 +1,21 @@
+package io.smallrye.faulttolerance.reuse.mixed.sync.fallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseSyncFallbackTest {
+    @Test
+    public void test(MyService service) {
+        assertThat(service.hello()).isEqualTo("hello");
+        assertThat(MyService.STRING_COUNTER).hasValue(3);
+
+        assertThat(service.theAnswer()).isEqualTo(42);
+        assertThat(MyService.INT_COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/fallback/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/fallback/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.mixed.sync.fallback;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withRetry().maxRetries(2).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/fallback/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/fallback/MyService.java
@@ -1,0 +1,37 @@
+package io.smallrye.faulttolerance.reuse.mixed.sync.fallback;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger STRING_COUNTER = new AtomicInteger(0);
+    static final AtomicInteger INT_COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "helloFallback")
+    public String hello() {
+        STRING_COUNTER.incrementAndGet();
+        throw new IllegalArgumentException();
+    }
+
+    String helloFallback() {
+        return "hello";
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "theAnswerFallback")
+    public int theAnswer() {
+        INT_COUNTER.incrementAndGet();
+        throw new IllegalArgumentException();
+    }
+
+    int theAnswerFallback() {
+        return 42;
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/threadoffload/MixedReuseSyncThreadOffloadTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/threadoffload/MixedReuseSyncThreadOffloadTest.java
@@ -1,0 +1,23 @@
+package io.smallrye.faulttolerance.reuse.mixed.sync.threadoffload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class MixedReuseSyncThreadOffloadTest {
+    @Test
+    public void test(MyService service) {
+        Thread currentThread = Thread.currentThread();
+
+        assertThat(service.hello()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD_STRING).hasValue(currentThread);
+
+        assertThat(service.theAnswer()).isEqualTo(42);
+        assertThat(MyService.CURRENT_THREAD_INT).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/threadoffload/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/threadoffload/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.mixed.sync.threadoffload;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/threadoffload/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/mixed/sync/threadoffload/MyService.java
@@ -1,0 +1,25 @@
+package io.smallrye.faulttolerance.reuse.mixed.sync.threadoffload;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD_STRING = new AtomicReference<>();
+    static final AtomicReference<Thread> CURRENT_THREAD_INT = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public String hello() {
+        CURRENT_THREAD_STRING.set(Thread.currentThread());
+        return "hello";
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    public int theAnswer() {
+        CURRENT_THREAD_INT.set(Thread.currentThread());
+        return 42;
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/guard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/guard/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.sync.fallback.guard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withRetry().maxRetries(2).done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/guard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/guard/MyService.java
@@ -1,0 +1,25 @@
+package io.smallrye.faulttolerance.reuse.sync.fallback.guard;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        COUNTER.incrementAndGet();
+        throw new IllegalArgumentException();
+    }
+
+    String fallback() {
+        return "better fallback";
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/guard/ReuseSyncFallbackGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/guard/ReuseSyncFallbackGuardTest.java
@@ -1,0 +1,18 @@
+package io.smallrye.faulttolerance.reuse.sync.fallback.guard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseSyncFallbackGuardTest {
+    @Test
+    public void test(MyService service) {
+        assertThat(service.hello()).isEqualTo("better fallback");
+        assertThat(MyService.COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/typedguard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/typedguard/MyFaultTolerance.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.reuse.sync.fallback.typedguard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.TypedGuard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final TypedGuard<String> GUARD = TypedGuard.create(String.class)
+            .withRetry().maxRetries(2).done()
+            .withFallback().handler(() -> "fallback").done()
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/typedguard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/typedguard/MyService.java
@@ -1,0 +1,25 @@
+package io.smallrye.faulttolerance.reuse.sync.fallback.typedguard;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        COUNTER.incrementAndGet();
+        throw new IllegalArgumentException();
+    }
+
+    String fallback() {
+        return "better fallback";
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/typedguard/ReuseSyncFallbackTypedGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/fallback/typedguard/ReuseSyncFallbackTypedGuardTest.java
@@ -1,0 +1,18 @@
+package io.smallrye.faulttolerance.reuse.sync.fallback.typedguard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseSyncFallbackTypedGuardTest {
+    @Test
+    public void test(MyService service) {
+        assertThat(service.hello()).isEqualTo("better fallback");
+        assertThat(MyService.COUNTER).hasValue(3);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/guard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/guard/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.sync.threadoffload.guard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final Guard GUARD = Guard.create()
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/guard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/guard/MyService.java
@@ -1,0 +1,18 @@
+package io.smallrye.faulttolerance.reuse.sync.threadoffload.guard;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public String hello() {
+        CURRENT_THREAD.set(Thread.currentThread());
+        return "hello";
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/guard/ReuseSyncThreadOffloadGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/guard/ReuseSyncThreadOffloadGuardTest.java
@@ -1,0 +1,20 @@
+package io.smallrye.faulttolerance.reuse.sync.threadoffload.guard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseSyncThreadOffloadGuardTest {
+    @Test
+    public void test(MyService service) {
+        Thread currentThread = Thread.currentThread();
+
+        assertThat(service.hello()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/typedguard/MyFaultTolerance.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/typedguard/MyFaultTolerance.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.reuse.sync.threadoffload.typedguard;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.TypedGuard;
+
+@ApplicationScoped
+public class MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    public static final TypedGuard<String> GUARD = TypedGuard.create(String.class)
+            .withThreadOffload(true)
+            .build();
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/typedguard/MyService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/typedguard/MyService.java
@@ -1,0 +1,18 @@
+package io.smallrye.faulttolerance.reuse.sync.threadoffload.typedguard;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class MyService {
+    static final AtomicReference<Thread> CURRENT_THREAD = new AtomicReference<>();
+
+    @ApplyGuard("my-fault-tolerance")
+    public String hello() {
+        CURRENT_THREAD.set(Thread.currentThread());
+        return "hello";
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/typedguard/ReuseSyncThreadOffloadTypedGuardTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/reuse/sync/threadoffload/typedguard/ReuseSyncThreadOffloadTypedGuardTest.java
@@ -1,0 +1,20 @@
+package io.smallrye.faulttolerance.reuse.sync.threadoffload.typedguard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance.class)
+public class ReuseSyncThreadOffloadTypedGuardTest {
+    @Test
+    public void test(MyService service) {
+        Thread currentThread = Thread.currentThread();
+
+        assertThat(service.hello()).isEqualTo("hello");
+        assertThat(MyService.CURRENT_THREAD).hasValue(currentThread);
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/guard/MyFaultTolerance.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/guard/MyFaultTolerance.kt
@@ -1,0 +1,15 @@
+package io.smallrye.faulttolerance.kotlin.reuse.fallback.guard
+
+import io.smallrye.common.annotation.Identifier
+import io.smallrye.faulttolerance.api.Guard
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+
+@ApplicationScoped
+object MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    val GUARD = Guard.create()
+        .withRetry().maxRetries(2).done()
+        .build()
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/guard/MyService.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/guard/MyService.kt
@@ -1,0 +1,22 @@
+package io.smallrye.faulttolerance.kotlin.reuse.fallback.guard
+
+import io.smallrye.faulttolerance.api.ApplyGuard
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.faulttolerance.Fallback
+import java.util.concurrent.atomic.AtomicInteger
+
+@ApplicationScoped
+open class MyService {
+    companion object {
+        val COUNTER = AtomicInteger(0)
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "fallback")
+    open fun hello(): String {
+        COUNTER.incrementAndGet()
+        throw IllegalArgumentException()
+    }
+
+    private fun fallback() = "better fallback"
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/guard/ReuseKotlinFallbackGuardTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/guard/ReuseKotlinFallbackGuardTest.kt
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.kotlin.reuse.fallback.guard
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import org.assertj.core.api.Assertions.assertThat
+import org.jboss.weld.junit5.auto.AddBeanClasses
+import org.junit.jupiter.api.Test
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance::class)
+class ReuseKotlinFallbackGuardTest {
+    @Test
+    fun test(service: MyService) {
+        assertThat(service.hello()).isEqualTo("better fallback")
+        assertThat(MyService.COUNTER).hasValue(3)
+    }
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/typedguard/MyFaultTolerance.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/typedguard/MyFaultTolerance.kt
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.kotlin.reuse.fallback.typedguard
+
+import io.smallrye.common.annotation.Identifier
+import io.smallrye.faulttolerance.api.TypedGuard
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import java.util.function.Supplier
+
+@ApplicationScoped
+object MyFaultTolerance {
+    @Produces
+    @Identifier("my-fault-tolerance")
+    val GUARD = TypedGuard.create(String::class.java)
+        .withRetry().maxRetries(2).done()
+        .withFallback().handler(Supplier { "fallback" }).done()
+        .build()
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/typedguard/MyService.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/typedguard/MyService.kt
@@ -1,0 +1,22 @@
+package io.smallrye.faulttolerance.kotlin.reuse.fallback.typedguard
+
+import io.smallrye.faulttolerance.api.ApplyGuard
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.faulttolerance.Fallback
+import java.util.concurrent.atomic.AtomicInteger
+
+@ApplicationScoped
+open class MyService {
+    companion object {
+        val COUNTER = AtomicInteger(0)
+    }
+
+    @ApplyGuard("my-fault-tolerance")
+    @Fallback(fallbackMethod = "fallback")
+    open fun hello(): String {
+        COUNTER.incrementAndGet()
+        throw IllegalArgumentException()
+    }
+
+    private fun fallback() = "better fallback"
+}

--- a/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/typedguard/ReuseKotlinFallbackTypedGuardTest.kt
+++ b/testsuite/basic/src/test/kotlin/io/smallrye/faulttolerance/kotlin/reuse/fallback/typedguard/ReuseKotlinFallbackTypedGuardTest.kt
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.kotlin.reuse.fallback.typedguard
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest
+import org.assertj.core.api.Assertions.assertThat
+import org.jboss.weld.junit5.auto.AddBeanClasses
+import org.junit.jupiter.api.Test
+
+@FaultToleranceBasicTest
+@AddBeanClasses(MyFaultTolerance::class)
+class ReuseKotlinFallbackTypedGuardTest {
+    @Test
+    fun test(service: MyService) {
+        assertThat(service.hello()).isEqualTo("better fallback")
+        assertThat(MyService.COUNTER).hasValue(3)
+    }
+}


### PR DESCRIPTION
Declarative `@Fallback` is used with both `Guard` and `TypedGuard` and if the `TypedGuard` defines a fallback, the `@Fallback` annotation takes priority.

Declarative thread offload (figuring out when thread offload is needed and when not) overrides the `Guard` / `TypedGuard` configuration if the annotated method is determined to be asynchronous; only if it is not the programmatic configuration is used.