### PR TITLE
docs: Add io.smallrye:smallrye-fault-tolerance-apiimpl module to the …

### DIFF
--- a/doc/modules/ROOT/pages/integration/intro.adoc
+++ b/doc/modules/ROOT/pages/integration/intro.adoc
@@ -3,6 +3,7 @@
 {smallrye-fault-tolerance} comprises the following main artifacts:
 
 * `io.smallrye:smallrye-fault-tolerance-api`: public API for the features provided on top of {microprofile-fault-tolerance}, including a programmatic API;
+* `io.smallrye:smallrye-fault-tolerance-apiimpl`: implementation of the programmatic API;
 * `io.smallrye:smallrye-fault-tolerance-core`: core implementations of fault tolerance strategies;
 * `io.smallrye:smallrye-fault-tolerance`: CDI-based implementation of {microprofile-fault-tolerance} with {smallrye-fault-tolerance} extensions, including a programmatic API;
 * `io.smallrye:smallrye-fault-tolerance-autoconfig-core`: runtime part of the {smallrye-fault-tolerance} configuration system.

--- a/doc/modules/ROOT/pages/internals/project-structure.adoc
+++ b/doc/modules/ROOT/pages/internals/project-structure.adoc
@@ -4,7 +4,10 @@
   Treated as a public API.
 * `implementation/core`: Implementation of core fault tolerance strategies.
   Independent of the {microprofile-fault-tolerance} API or the {smallrye-fault-tolerance} API.
-   Treated as private API, no compatibility guaranteed.
+  Treated as private API, no compatibility guaranteed.
+* `implementation/apiimpl`: Implementation of the programmatic API.
+  Based on the `core` module.
+  Treated as private API, no compatibility guaranteed.
 * `implementation/fault-tolerance`: Implementation of the {microprofile-fault-tolerance} API and the {smallrye-fault-tolerance} API.
   Based on CDI and the `core` module.
   The configuration system is based on the `autoconfig` module.


### PR DESCRIPTION
…list of required modules since 6.8.0