### PR TITLE
fix memory leak in metrics

### DIFF
--- a/api/src/main/java/io/smallrye/faulttolerance/api/Guard.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/Guard.java
@@ -165,7 +165,7 @@ public interface Guard {
          * <p>
          * The description may be an arbitrary string. Duplicates are permitted.
          * <p>
-         * If no description is set, a random UUID is used.
+         * If no description is set, no metrics are emitted and a random UUID is used for other purposes.
          *
          * @param value a description, must not be {@code null}
          * @return this fault tolerance builder

--- a/api/src/main/java/io/smallrye/faulttolerance/api/TypedGuard.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/TypedGuard.java
@@ -136,7 +136,7 @@ public interface TypedGuard<T> {
          * <p>
          * The description may be an arbitrary string. Duplicates are permitted.
          * <p>
-         * If no description is set, a random UUID is used.
+         * If no description is set, no metrics are emitted and a random UUID is used for other purposes.
          *
          * @param value a description, must not be {@code null}
          * @return this fault tolerance builder

--- a/doc/modules/ROOT/pages/reference/programmatic-api.adoc
+++ b/doc/modules/ROOT/pages/reference/programmatic-api.adoc
@@ -264,7 +264,7 @@ private static final Guard GUARD = Guard.create()
 It is possible to create multiple `Guard` objects with the same description.
 In this case, it won't be possible to distinguish the different `Guard` objects in metrics; their values will be aggregated.
 
-If no description is provided, a random UUID is used.
+If no description is provided, metrics are not emitted.
 
 == Differences to the Specification
 

--- a/implementation/apiimpl/src/main/java/io/smallrye/faulttolerance/apiimpl/BasicMeteredOperationImpl.java
+++ b/implementation/apiimpl/src/main/java/io/smallrye/faulttolerance/apiimpl/BasicMeteredOperationImpl.java
@@ -3,6 +3,7 @@ package io.smallrye.faulttolerance.apiimpl;
 import io.smallrye.faulttolerance.core.metrics.MeteredOperation;
 
 final class BasicMeteredOperationImpl implements MeteredOperation {
+    private final boolean enabled;
     private final String name;
     private final boolean mayBeAsynchronous;
     private final boolean hasBulkhead;
@@ -12,8 +13,9 @@ final class BasicMeteredOperationImpl implements MeteredOperation {
     private final boolean hasRetry;
     private final boolean hasTimeout;
 
-    BasicMeteredOperationImpl(String name, boolean mayBeAsynchronous, boolean hasBulkhead, boolean hasCircuitBreaker,
-            boolean hasFallback, boolean hasRateLimit, boolean hasRetry, boolean hasTimeout) {
+    BasicMeteredOperationImpl(boolean enabled, String name, boolean mayBeAsynchronous, boolean hasBulkhead,
+            boolean hasCircuitBreaker, boolean hasFallback, boolean hasRateLimit, boolean hasRetry, boolean hasTimeout) {
+        this.enabled = enabled;
         this.name = name;
         this.mayBeAsynchronous = mayBeAsynchronous;
         this.hasBulkhead = hasBulkhead;
@@ -22,6 +24,11 @@ final class BasicMeteredOperationImpl implements MeteredOperation {
         this.hasRateLimit = hasRateLimit;
         this.hasRetry = hasRetry;
         this.hasTimeout = hasTimeout;
+    }
+
+    @Override
+    public boolean enabled() {
+        return enabled;
     }
 
     @Override

--- a/implementation/apiimpl/src/main/java/io/smallrye/faulttolerance/apiimpl/FaultToleranceImpl.java
+++ b/implementation/apiimpl/src/main/java/io/smallrye/faulttolerance/apiimpl/FaultToleranceImpl.java
@@ -181,6 +181,7 @@ public final class FaultToleranceImpl<V, T> implements FaultTolerance<T> {
         private final Function<FaultTolerance<T>, R> finisher;
 
         private String description;
+        private boolean descriptionSet;
         private BulkheadBuilderImpl<T, R> bulkheadBuilder;
         private CircuitBreakerBuilderImpl<T, R> circuitBreakerBuilder;
         private FallbackBuilderImpl<T, R> fallbackBuilder;
@@ -199,11 +200,13 @@ public final class FaultToleranceImpl<V, T> implements FaultTolerance<T> {
             this.finisher = finisher;
 
             this.description = UUID.randomUUID().toString();
+            this.descriptionSet = false;
         }
 
         @Override
         public Builder<T, R> withDescription(String value) {
             this.description = checkNotNull(value, "Description must be set");
+            this.descriptionSet = true;
             return this;
         }
 
@@ -476,7 +479,7 @@ public final class FaultToleranceImpl<V, T> implements FaultTolerance<T> {
         }
 
         private MeteredOperation buildMeteredOperation() {
-            return new BasicMeteredOperationImpl(description, isAsync, bulkheadBuilder != null,
+            return new BasicMeteredOperationImpl(descriptionSet, description, isAsync, bulkheadBuilder != null,
                     circuitBreakerBuilder != null, fallbackBuilder != null, rateLimitBuilder != null,
                     retryBuilder != null, timeoutBuilder != null);
         }

--- a/implementation/apiimpl/src/main/java/io/smallrye/faulttolerance/apiimpl/GuardImpl.java
+++ b/implementation/apiimpl/src/main/java/io/smallrye/faulttolerance/apiimpl/GuardImpl.java
@@ -131,6 +131,7 @@ public class GuardImpl implements Guard {
         private final BuilderEagerDependencies eagerDependencies;
         private final Supplier<BuilderLazyDependencies> lazyDependencies;
         private String description;
+        private boolean descriptionSet;
         private BulkheadBuilderImpl bulkheadBuilder;
         private CircuitBreakerBuilderImpl circuitBreakerBuilder;
         private RateLimitBuilderImpl rateLimitBuilder;
@@ -144,11 +145,13 @@ public class GuardImpl implements Guard {
             this.lazyDependencies = lazyDependencies;
 
             this.description = UUID.randomUUID().toString();
+            this.descriptionSet = false;
         }
 
         @Override
         public Builder withDescription(String value) {
             this.description = checkNotNull(value, "Description must be set");
+            this.descriptionSet = true;
             return this;
         }
 
@@ -314,7 +317,7 @@ public class GuardImpl implements Guard {
         }
 
         private MeteredOperation buildMeteredOperation() {
-            return new BasicMeteredOperationImpl(description, true, bulkheadBuilder != null,
+            return new BasicMeteredOperationImpl(descriptionSet, description, true, bulkheadBuilder != null,
                     circuitBreakerBuilder != null, false, rateLimitBuilder != null,
                     retryBuilder != null, timeoutBuilder != null);
         }

--- a/implementation/apiimpl/src/main/java/io/smallrye/faulttolerance/apiimpl/TypedGuardImpl.java
+++ b/implementation/apiimpl/src/main/java/io/smallrye/faulttolerance/apiimpl/TypedGuardImpl.java
@@ -122,6 +122,7 @@ public final class TypedGuardImpl<V, T> implements TypedGuard<T> {
         private final AsyncSupport<V, T> asyncSupport;
 
         private String description;
+        private boolean descriptionSet;
         private BulkheadBuilderImpl<V, T> bulkheadBuilder;
         private CircuitBreakerBuilderImpl<V, T> circuitBreakerBuilder;
         private FallbackBuilderImpl<V, T> fallbackBuilder;
@@ -138,11 +139,13 @@ public final class TypedGuardImpl<V, T> implements TypedGuard<T> {
             this.asyncSupport = GuardCommon.asyncSupport(valueType);
 
             this.description = UUID.randomUUID().toString();
+            this.descriptionSet = false;
         }
 
         @Override
         public Builder<T> withDescription(String value) {
             this.description = checkNotNull(value, "Description must be set");
+            this.descriptionSet = true;
             return this;
         }
 
@@ -335,7 +338,7 @@ public final class TypedGuardImpl<V, T> implements TypedGuard<T> {
         }
 
         private MeteredOperation buildMeteredOperation() {
-            return new BasicMeteredOperationImpl(description, asyncSupport != null, bulkheadBuilder != null,
+            return new BasicMeteredOperationImpl(descriptionSet, description, asyncSupport != null, bulkheadBuilder != null,
                     circuitBreakerBuilder != null, false, rateLimitBuilder != null,
                     retryBuilder != null, timeoutBuilder != null);
         }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingMeteredOperation.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingMeteredOperation.java
@@ -10,6 +10,12 @@ final class DelegatingMeteredOperation implements MeteredOperation {
     }
 
     @Override
+    public boolean enabled() {
+        // always enabled, because this class is only instantiated for intercepted methods
+        return true;
+    }
+
+    @Override
     public boolean mayBeAsynchronous() {
         return operation.mayBeAsynchronous();
     }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingMetricsCollector.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/DelegatingMetricsCollector.java
@@ -27,8 +27,13 @@ public class DelegatingMetricsCollector<V> implements FaultToleranceStrategy<V> 
         MeteredOperation operation = name != null
                 ? new DelegatingMeteredOperation(originalOperation, name.get())
                 : originalOperation;
-        MetricsCollector<V> delegate = cache.computeIfAbsent(operation,
-                ignored -> new MetricsCollector<>(this.delegate, provider.create(operation), operation));
+        FaultToleranceStrategy<V> delegate;
+        if (operation.enabled()) {
+            delegate = cache.computeIfAbsent(operation,
+                    ignored -> new MetricsCollector<>(this.delegate, provider.create(operation), operation));
+        } else {
+            delegate = this.delegate;
+        }
         return delegate.apply(ctx);
     }
 }

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/MeteredOperation.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/MeteredOperation.java
@@ -1,6 +1,8 @@
 package io.smallrye.faulttolerance.core.metrics;
 
 public interface MeteredOperation {
+    boolean enabled();
+
     boolean mayBeAsynchronous();
 
     boolean hasBulkhead();

--- a/implementation/core/src/test/java/io/smallrye/faulttolerance/core/metrics/GeneralMetricsTest.java
+++ b/implementation/core/src/test/java/io/smallrye/faulttolerance/core/metrics/GeneralMetricsTest.java
@@ -41,6 +41,11 @@ public class GeneralMetricsTest {
 
     private static class MockMeteredOperation implements MeteredOperation {
         @Override
+        public boolean enabled() {
+            return true;
+        }
+
+        @Override
         public boolean mayBeAsynchronous() {
             return false;
         }

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/CdiMeteredOperationImpl.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/metrics/CdiMeteredOperationImpl.java
@@ -18,6 +18,12 @@ public final class CdiMeteredOperationImpl implements MeteredOperation {
     }
 
     @Override
+    public boolean enabled() {
+        // always enabled, because this only applies to intercepted methods
+        return true;
+    }
+
+    @Override
     public boolean mayBeAsynchronous() {
         return specCompatibility.isOperationTrulyOrPseudoAsynchronous(operation);
     }

--- a/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneMetricsTest.java
+++ b/implementation/standalone/src/test/java/io/smallrye/faulttolerance/standalone/test/StandaloneMetricsTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -62,7 +63,9 @@ public class StandaloneMetricsTest {
     }
 
     @Test
-    public void test() throws Exception {
+    public void metricsWithDescription() throws Exception {
+        long oldCounters = metrics.getMeters().stream().filter(it -> it instanceof Counter).count();
+
         Callable<String> guarded = TypedGuard.create(String.class)
                 .withDescription(NAME)
                 .withFallback().handler(this::fallback).done()
@@ -71,6 +74,8 @@ public class StandaloneMetricsTest {
                 .adaptCallable(this::action);
 
         assertThat(guarded.call()).isEqualTo("fallback");
+
+        assertThat(metrics.getMeters().stream().filter(it -> it instanceof Counter).count()).isGreaterThan(oldCounters);
 
         assertThat(metrics.counter(MetricsConstants.INVOCATIONS_TOTAL, List.of(
                 Tag.of("method", NAME),
@@ -86,6 +91,21 @@ public class StandaloneMetricsTest {
                 Tag.of("retried", "true"),
                 Tag.of("retryResult", "maxRetriesReached")))
                 .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    public void noMetricsWithoutDescription() throws Exception {
+        long oldCounters = metrics.getMeters().stream().filter(it -> it instanceof Counter).count();
+
+        Callable<String> guarded = TypedGuard.create(String.class)
+                .withFallback().handler(this::fallback).done()
+                .withRetry().maxRetries(3).done()
+                .build()
+                .adaptCallable(this::action);
+
+        assertThat(guarded.call()).isEqualTo("fallback");
+
+        assertThat(metrics.getMeters().stream().filter(it -> it instanceof Counter).count()).isEqualTo(oldCounters);
     }
 
     public String action() throws TestException {


### PR DESCRIPTION
The issue is that a random UUID is used as a value of the metrics tag `method` if the user doesn't set a description on `Guard` / `TypedGuard` and doesn't use them with `@ApplyGuard`. These values are always held in memory, so in case more and more `Guard` / `TypedGuard` objects without description are created, more and more memory is held.

The fix is relatively simple: in case no description is set (and a random UUID should be used), no metrics are emitted. This is technically a breaking change, but it's better to require users to explicitly state the value of the metrics tag than to leak memory.

(The same applies to the old `FaultTolerance` and `@ApplyFaultTolerance` API.)

Fixes #1108