### PR TITLE
[6.4] fix memory leak in metrics

### DIFF
--- a/api/src/main/java/io/smallrye/faulttolerance/api/FaultTolerance.java
+++ b/api/src/main/java/io/smallrye/faulttolerance/api/FaultTolerance.java
@@ -244,7 +244,7 @@ public interface FaultTolerance<T> {
          * <p>
          * The description may be an arbitrary string. Duplicates are permitted.
          * <p>
-         * If no description is set, a random UUID is used.
+         * If no description is set, no metrics are emitted and a random UUID is used for other purposes.
          *
          * @param value a description, must not be {@code null}
          * @return this fault tolerance builder

--- a/doc/modules/ROOT/pages/reference/programmatic-api.adoc
+++ b/doc/modules/ROOT/pages/reference/programmatic-api.adoc
@@ -352,7 +352,7 @@ private static final FaultTolerance<String> guarded = FaultTolerance.<String>cre
 It is possible to create multiple `FaultTolerance` objects with the same description.
 In this case, it won't be possbile to distinguish the different `FaultTolerance` objects in metrics; their values will be aggregated.
 
-If no description is provided, a random UUID is used.
+If no description is provided, metrics are not emitted.
 
 == Integration Concerns
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java
@@ -138,6 +138,7 @@ public final class FaultToleranceImpl<V, S, T> implements FaultTolerance<T> {
         private final Function<FaultTolerance<T>, R> finisher;
 
         private String description;
+        private boolean descriptionSet;
         private BulkheadBuilderImpl<T, R> bulkheadBuilder;
         private CircuitBreakerBuilderImpl<T, R> circuitBreakerBuilder;
         private FallbackBuilderImpl<T, R> fallbackBuilder;
@@ -156,11 +157,13 @@ public final class FaultToleranceImpl<V, S, T> implements FaultTolerance<T> {
             this.finisher = finisher;
 
             this.description = UUID.randomUUID().toString();
+            this.descriptionSet = false;
         }
 
         @Override
         public Builder<T, R> withDescription(String value) {
             this.description = Preconditions.checkNotNull(value, "Description must be set");
+            this.descriptionSet = true;
             return this;
         }
 
@@ -324,7 +327,7 @@ public final class FaultToleranceImpl<V, S, T> implements FaultTolerance<T> {
                                 fallbackBuilder.whenPredicate));
             }
 
-            if (lazyDependencies.metricsProvider().isEnabled()) {
+            if (lazyDependencies.metricsProvider().isEnabled() && descriptionSet) {
                 MeteredOperation meteredOperation = buildMeteredOperation();
                 result = new MetricsCollector<>(result, lazyDependencies.metricsProvider().create(meteredOperation),
                         meteredOperation);
@@ -406,7 +409,7 @@ public final class FaultToleranceImpl<V, S, T> implements FaultTolerance<T> {
                                 fallbackBuilder.whenPredicate));
             }
 
-            if (lazyDependencies.metricsProvider().isEnabled()) {
+            if (lazyDependencies.metricsProvider().isEnabled() && descriptionSet) {
                 MeteredOperation meteredOperation = buildMeteredOperation();
                 result = new CompletionStageMetricsCollector<>(result,
                         lazyDependencies.metricsProvider().create(meteredOperation), meteredOperation);


### PR DESCRIPTION
The issue is that a random UUID is used as a value of the metrics tag `method` if the user doesn't set a description on `FaultTolerance`. These values are always held in memory, so in case more and more `FaultTolerance` objects without description are created, more and more memory is held.

The fix is relatively simple: in case no description is set (and a random UUID should be used), no metrics are emitted. This is technically a breaking change, but it's better to require users to explicitly state the value of the metrics tag than to leak memory.