### PR TITLE
skip intercepting synthetic methods

### DIFF
--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceExtension.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/FaultToleranceExtension.java
@@ -237,6 +237,10 @@ public class FaultToleranceExtension implements Extension {
     void collectFaultToleranceOperations(@Observes ProcessManagedBean<?> event) {
         AnnotatedType<?> annotatedType = event.getAnnotatedBeanClass();
         for (AnnotatedMethod<?> annotatedMethod : annotatedType.getMethods()) {
+            if (annotatedMethod.getJavaMember().isSynthetic()) {
+                continue;
+            }
+
             FaultToleranceMethod method = FaultToleranceMethods.create(annotatedType.getJavaClass(), annotatedMethod);
             if (method.isLegitimate()) {
                 FaultToleranceOperation operation = new FaultToleranceOperation(method);


### PR DESCRIPTION
This is mostly for the JaCoCo coverage tool that we run automatically in CI, but also feels like the right thing to do in general.