### PR TITLE
bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,49 +37,68 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
+        <!--
+          - need to stay on Jakarta EE 10 dependencies for now, because:
+          - * Weld 6.0 requires Java 17, and we need to support Java 11 still
+          - * WildFly still supports Jakarta EE 10
+         -->
+
+        <!-- Jakarta Annotations: 2.1 is EE 10, 3.0 is EE 11, 3.1 will be EE 12 -->
         <version.jakarta-annotations>2.1.1</version.jakarta-annotations>
+        <!-- Jakarta CDI: 4.0 is EE 10, 4.1 is EE 11, 5.0 will be EE 12 -->
         <version.jakarta-cdi>4.0.1</version.jakarta-cdi>
+        <!-- Jakarta Interceptors: 2.1 is EE 10, 2.2 is EE 11 -->
         <version.jakarta-interceptors>2.1.0</version.jakarta-interceptors>
         <version.javapoet>1.13.0</version.javapoet>
-        <version.jboss-logging>3.6.0.Final</version.jboss-logging>
-        <version.jboss-logging-tools>2.2.1.Final</version.jboss-logging-tools>
-        <version.kotlin>1.9.24</version.kotlin>
-        <version.kotlin-dokka>1.9.20</version.kotlin-dokka>
-        <version.kotlinx-coroutines>1.8.1</version.kotlinx-coroutines>
+        <version.jboss-logging>3.6.1.Final</version.jboss-logging>
+        <version.jboss-logging-tools>3.0.4.Final</version.jboss-logging-tools>
+        <version.kotlin>2.2.20</version.kotlin>
+        <version.kotlin-dokka>2.0.0</version.kotlin-dokka>
+        <version.kotlinx-coroutines>1.10.2</version.kotlinx-coroutines>
+        <!-- Micrometer 1.13.0 has a breaking change in Prometheus library -->
         <version.micrometer-core>1.12.5</version.micrometer-core>
         <version.microprofile-fault-tolerance>4.1.2</version.microprofile-fault-tolerance>
         <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.microprofile-metrics-api>4.0.1</version.microprofile-metrics-api>
         <version.microprofile-context-propagation-api>1.3</version.microprofile-context-propagation-api>
-        <version.opentelemetry>1.39.0</version.opentelemetry>
+        <!-- this is the last Mutiny version that supports Java 11 -->
+        <version.mutiny>2.7.0</version.mutiny>
+        <!-- OpenTelemetry 1.48.0 is required by MicroProfile Telemetry 2.1 (MP Platform 7.1) -->
+        <version.opentelemetry>1.48.0</version.opentelemetry>
+        <version.opentracing>0.33.0</version.opentracing>
+        <version.rxjava3>3.1.12</version.rxjava3>
+        <!-- this is the last SmallRye Common version that supports Java 11 -->
+        <version.smallrye-common>2.8.0</version.smallrye-common>
         <!-- smallrye-config is purely used for testing -->
-        <version.smallrye-config>3.8.2</version.smallrye-config>
+        <!-- this is the last SmallRye Config version that supports Java 11 -->
+        <version.smallrye-config>3.10.2</version.smallrye-config>
+        <!-- smallrye-context-propagation is purely used for testing -->
+        <version.smallrye-context-propagation>2.2.1</version.smallrye-context-propagation>
         <!-- smallrye-metrics is purely used for testing -->
         <version.smallrye-metrics>4.0.0</version.smallrye-metrics>
-        <!-- smallrye-context-propagation is purely used for testing -->
-        <version.smallrye-context-propagation>2.1.0</version.smallrye-context-propagation>
         <!-- smallrye-opentelemetry is purely used for testing -->
-        <version.smallrye-opentelemetry>2.8.1</version.smallrye-opentelemetry>
-        <version.smallrye-common>2.4.0</version.smallrye-common>
-        <version.opentracing>0.33.0</version.opentracing>
-        <version.vertx>4.5.8</version.vertx>
+        <version.smallrye-opentelemetry>2.10.1</version.smallrye-opentelemetry>
+        <version.vertx>4.5.21</version.vertx>
 
-        <version.arquillian>1.8.0.Final</version.arquillian>
+        <version.arquillian>1.10.0.Final</version.arquillian>
+        <!-- Arquillian Weld: 3.0 is EE 10, 4.0 is EE 11 -->
         <version.arquillian-weld>3.0.2.Final</version.arquillian-weld>
-        <version.assertj>3.26.0</version.assertj>
-        <version.awaitility>4.2.2</version.awaitility>
-        <version.junit-jupiter>5.10.2</version.junit-jupiter>
-        <version.mutiny>2.6.0</version.mutiny>
-        <version.rxjava3>3.1.8</version.rxjava3>
-        <version.testng>7.10.2</version.testng>
+        <version.assertj>3.27.6</version.assertj>
+        <version.awaitility>4.3.0</version.awaitility>
+        <!-- JUnit Jupiter 6.0 makes small but breaking changes -->
+        <version.junit-jupiter>5.14.0</version.junit-jupiter>
+        <version.testng>7.11.0</version.testng>
+        <!-- Weld API: 5.0 is EE 10, 6.0 is EE 11, 7.0 will be EE 12 -->
         <version.weld-api>5.0.SP3</version.weld-api>
-        <version.weld-core>5.1.2.Final</version.weld-core>
-        <version.weld-junit5>4.0.3.Final</version.weld-junit5>
+        <!-- Weld Core: 5.1 is EE 10, 6.0 is EE 11, 7.0 will be EE 12 -->
+        <version.weld-core>5.1.6.Final</version.weld-core>
+        <!-- Weld JUnit: 4.0 is EE 10, 5.0 is EE 11 -->
+        <version.weld-junit5>4.0.5.Final</version.weld-junit5>
 
-        <version.jacoco-maven-plugin>0.8.12</version.jacoco-maven-plugin>
-        <version.pitest-maven>1.16.1</version.pitest-maven>
-        <version.pitest-junit5-plugin>1.2.1</version.pitest-junit5-plugin>
-        <version.sundrio>0.201.0</version.sundrio>
+        <version.jacoco-maven-plugin>0.8.13</version.jacoco-maven-plugin>
+        <version.pitest-maven>1.20.5</version.pitest-maven>
+        <version.pitest-junit5-plugin>1.2.3</version.pitest-junit5-plugin>
+        <version.sundrio>0.230.0</version.sundrio>
 
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -64,6 +64,12 @@
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-tck</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This commit intentionally stays on Jakarta EE 10 dependencies, but all others are updated to the latest.

OpenTelemetry is an exception: it is updated to the latest version supported by the latest version of MicroProfile Telemetry.