### PR TITLE
fix annotation lookup when FT annotations come from a class-level stereotype

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Fault Tolerance
 release:
-  current-version: 6.11.0
-  next-version: 6.11.1-SNAPSHOT
+  current-version: 6.11.1
+  next-version: 6.11.2-SNAPSHOT

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-api</artifactId>

--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,13 +1,13 @@
 name: smallrye-fault-tolerance
 title: SmallRye Fault Tolerance
-version: main
+version: 6.11.1
 nav:
 - modules/ROOT/nav.adoc
 
 asciidoc:
   attributes:
     smallrye-fault-tolerance: SmallRye Fault Tolerance
-    smallrye-fault-tolerance-version: '6.11.0'
+    smallrye-fault-tolerance-version: '6.11.1'
 
     microprofile-fault-tolerance: MicroProfile Fault Tolerance
     microprofile-fault-tolerance-version: '4.1.2'

--- a/implementation/apiimpl/pom.xml
+++ b/implementation/apiimpl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-apiimpl</artifactId>

--- a/implementation/autoconfig/core/pom.xml
+++ b/implementation/autoconfig/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-autoconfig-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>

--- a/implementation/autoconfig/pom.xml
+++ b/implementation/autoconfig/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-autoconfig-parent</artifactId>

--- a/implementation/autoconfig/processor/pom.xml
+++ b/implementation/autoconfig/processor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-autoconfig-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-autoconfig-processor</artifactId>

--- a/implementation/context-propagation/pom.xml
+++ b/implementation/context-propagation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-context-propagation</artifactId>

--- a/implementation/core/pom.xml
+++ b/implementation/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-core</artifactId>

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/MicrometerRecorder.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/MicrometerRecorder.java
@@ -123,8 +123,8 @@ public class MicrometerRecorder implements MetricsRecorder {
         }
 
         if (operation.hasRateLimit()) {
-            registry.counter(RATE_LIMIT_CALLS_TOTAL, Arrays.asList(methodTag, BULKHEAD_RESULT_ACCEPTED));
-            registry.counter(RATE_LIMIT_CALLS_TOTAL, Arrays.asList(methodTag, BULKHEAD_RESULT_REJECTED));
+            registry.counter(RATE_LIMIT_CALLS_TOTAL, Arrays.asList(methodTag, RATE_LIMIT_RESULT_PERMITTED));
+            registry.counter(RATE_LIMIT_CALLS_TOTAL, Arrays.asList(methodTag, RATE_LIMIT_RESULT_REJECTED));
         }
     }
 

--- a/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/MicrometerRecorder.java
+++ b/implementation/core/src/main/java/io/smallrye/faulttolerance/core/metrics/MicrometerRecorder.java
@@ -76,7 +76,7 @@ public class MicrometerRecorder implements MetricsRecorder {
 
         if (operation.hasFallback()) {
             registry.counter(INVOCATIONS_TOTAL, Arrays.asList(methodTag, RESULT_VALUE_RETURNED, FALLBACK_NOT_APPLIED));
-            registry.counter(INVOCATIONS_TOTAL, Arrays.asList(methodTag, RESULT_VALUE_RETURNED, FALLBACK_APPLIED)).count();
+            registry.counter(INVOCATIONS_TOTAL, Arrays.asList(methodTag, RESULT_VALUE_RETURNED, FALLBACK_APPLIED));
             registry.counter(INVOCATIONS_TOTAL, Arrays.asList(methodTag, RESULT_EXCEPTION_THROWN, FALLBACK_NOT_APPLIED));
             registry.counter(INVOCATIONS_TOTAL, Arrays.asList(methodTag, RESULT_EXCEPTION_THROWN, FALLBACK_APPLIED));
         } else {

--- a/implementation/fault-tolerance/pom.xml
+++ b/implementation/fault-tolerance/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance</artifactId>

--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceMethods.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceMethods.java
@@ -5,11 +5,13 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.security.PrivilegedActionException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.enterprise.inject.Stereotype;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -92,10 +94,12 @@ public class FaultToleranceMethods {
             directlyPresent.add(annotationType);
             return cdiMethod.getAnnotation(annotationType);
         }
-        return cdiMethod.getDeclaringType().getAnnotation(annotationType);
+        A annotation = cdiMethod.getDeclaringType().getAnnotation(annotationType);
+        if (annotation == null) {
+            annotation = findInStereotypes(cdiMethod.getDeclaringType().getAnnotations(), annotationType);
+        }
+        return annotation;
     }
-
-    // ---
 
     public static FaultToleranceMethod create(Class<?> beanClass, Method method) {
         Set<Class<? extends Annotation>> annotationsPresentDirectly = new HashSet<>();
@@ -160,6 +164,9 @@ public class FaultToleranceMethods {
     private static <A extends Annotation> A getAnnotationFromClass(Class<?> clazz, Class<A> annotationType) {
         while (clazz != null) {
             A annotation = clazz.getAnnotation(annotationType);
+            if (annotation == null) {
+                annotation = findInStereotypes(Arrays.asList(clazz.getAnnotations()), annotationType);
+            }
             if (annotation != null) {
                 return annotation;
             }
@@ -167,8 +174,6 @@ public class FaultToleranceMethods {
         }
         return null;
     }
-
-    // ---
 
     private static void searchForMethods(FaultToleranceMethod result, Class<?> beanClass, Method method)
             throws PrivilegedActionException {
@@ -215,5 +220,33 @@ public class FaultToleranceMethods {
             result.add(createMethodDescriptor(reflectiveMethod));
         }
         return result;
+    }
+
+    private static <A extends Annotation> A findInStereotypes(
+            Collection<Annotation> classAnnotations, Class<A> annotationType) {
+        return findInStereotypes(classAnnotations, annotationType, new HashSet<>());
+    }
+
+    private static <A extends Annotation> A findInStereotypes(
+            Collection<Annotation> classAnnotations, Class<A> annotationType,
+            Set<Class<? extends Annotation>> visited) {
+        for (Annotation classAnnotation : classAnnotations) {
+            Class<? extends Annotation> stereotypeType = classAnnotation.annotationType();
+            if (!stereotypeType.isAnnotationPresent(Stereotype.class)) {
+                continue;
+            }
+            if (!visited.add(stereotypeType)) {
+                continue;
+            }
+            A found = stereotypeType.getAnnotation(annotationType);
+            if (found != null) {
+                return found;
+            }
+            found = findInStereotypes(Arrays.asList(stereotypeType.getAnnotations()), annotationType, visited);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
     }
 }

--- a/implementation/kotlin/pom.xml
+++ b/implementation/kotlin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-kotlin</artifactId>

--- a/implementation/mutiny/pom.xml
+++ b/implementation/mutiny/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-mutiny</artifactId>

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>

--- a/implementation/rxjava3/pom.xml
+++ b/implementation/rxjava3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-rxjava3</artifactId>

--- a/implementation/standalone/pom.xml
+++ b/implementation/standalone/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-standalone</artifactId>

--- a/implementation/tracing-propagation/pom.xml
+++ b/implementation/tracing-propagation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-tracing-propagation</artifactId>

--- a/implementation/vertx/pom.xml
+++ b/implementation/vertx/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-implementation-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-vertx</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <artifactId>smallrye-fault-tolerance-parent</artifactId>
-    <version>6.11.1-SNAPSHOT</version>
+    <version>6.11.1</version>
     <packaging>pom</packaging>
 
     <name>SmallRye Fault Tolerance: Parent</name>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:smallrye/smallrye-fault-tolerance.git</connection>
         <developerConnection>scm:git:git@github.com:smallrye/smallrye-fault-tolerance.git</developerConnection>
         <url>https://github.com/smallrye/smallrye-fault-tolerance/</url>
-        <tag>HEAD</tag>
+        <tag>6.11.1</tag>
     </scm>
 
     <modules>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-release</artifactId>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>smallrye-fault-tolerance-testsuite-parent</artifactId>
         <groupId>io.smallrye</groupId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-testsuite-basic</artifactId>

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/CompositeStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/CompositeStereotype.java
@@ -1,0 +1,20 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+@Stereotype
+@RetryStereotype
+@CircuitBreaker(requestVolumeThreshold = 4, failureRatio = 0.5, delay = 5000)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface CompositeStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/FtStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/FtStereotype.java
@@ -1,0 +1,26 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.temporal.ChronoUnit;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@Stereotype
+@Retry(maxRetries = 2, delay = 50, delayUnit = ChronoUnit.MILLIS)
+@CircuitBreaker(requestVolumeThreshold = 4, failureRatio = 0.5, delay = 5000)
+@Timeout(value = 2, unit = ChronoUnit.SECONDS)
+@Bulkhead(value = 10)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface FtStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NestedStereotypeService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NestedStereotypeService.java
@@ -1,0 +1,32 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@CompositeStereotype
+@ApplicationScoped
+public class NestedStereotypeService {
+
+    private final AtomicInteger callCount = new AtomicInteger(0);
+
+    AtomicInteger getCallCount() {
+        return callCount;
+    }
+
+    void resetCallCount() {
+        callCount.set(0);
+    }
+
+    @Fallback(fallbackMethod = "fallback")
+    public String work() {
+        callCount.incrementAndGet();
+        throw new RuntimeException("transient failure");
+    }
+
+    String fallback() {
+        return "fallback";
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/RetryStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/RetryStereotype.java
@@ -1,0 +1,20 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.temporal.ChronoUnit;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Stereotype
+@Retry(maxRetries = 2, delay = 50, delayUnit = ChronoUnit.MILLIS)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RetryStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/SameLevelService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/SameLevelService.java
@@ -1,0 +1,40 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@ApplicationScoped
+public class SameLevelService {
+
+    private final AtomicInteger callCount = new AtomicInteger(0);
+
+    AtomicInteger getCallCount() {
+        return callCount;
+    }
+
+    void resetCallCount() {
+        callCount.set(0);
+    }
+
+    @Retry(maxRetries = 2, delay = 50, delayUnit = ChronoUnit.MILLIS)
+    @CircuitBreaker(requestVolumeThreshold = 4, failureRatio = 0.5, delay = 5000)
+    @Timeout(value = 2, unit = ChronoUnit.SECONDS)
+    @Bulkhead(value = 10)
+    @Fallback(fallbackMethod = "fallback")
+    public String work() {
+        callCount.incrementAndGet();
+        throw new RuntimeException("transient failure");
+    }
+
+    String fallback() {
+        return "fallback";
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/StereotypeFallbackOrderingTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/StereotypeFallbackOrderingTest.java
@@ -1,0 +1,75 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.IntStream;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.api.CircuitBreakerMaintenance;
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class StereotypeFallbackOrderingTest {
+
+    @Inject
+    StereotypeService service;
+
+    @Inject
+    SameLevelService sameLevelService;
+
+    @Inject
+    NestedStereotypeService nestedStereotypeService;
+
+    @Inject
+    CircuitBreakerMaintenance maintenance;
+
+    @BeforeEach
+    void setUp() {
+        service.resetCallCount();
+        sameLevelService.resetCallCount();
+        nestedStereotypeService.resetCallCount();
+        maintenance.resetAll();
+    }
+
+    @Test
+    public void retryIteratesBeforeFallback_whenAnnotationsCrossClassAndMethodLevels() {
+        service.work();
+
+        assertThat(service.getCallCount().get()).isEqualTo(3);
+    }
+
+    @Test
+    public void circuitBreakerAccumulatesFailures_whenFallbackIsAtMethodLevel() {
+        openCircuitBreaker();
+
+        service.resetCallCount();
+        service.work();
+
+        assertThat(service.getCallCount().get()).isZero();
+    }
+
+    @Test
+    public void retryIteratesBeforeFallback_whenAllAnnotationsAreAtMethodLevel() {
+        sameLevelService.work();
+
+        assertThat(sameLevelService.getCallCount().get()).isEqualTo(3);
+    }
+
+    @Test
+    public void retryIteratesBeforeFallback_whenAnnotationComesFromNestedStereotype() {
+        nestedStereotypeService.work();
+
+        assertThat(nestedStereotypeService.getCallCount().get()).isEqualTo(3);
+    }
+
+    private void openCircuitBreaker() {
+        IntStream.range(0, 3).forEach(ignored -> {
+            service.resetCallCount();
+            service.work();
+        });
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/StereotypeService.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/StereotypeService.java
@@ -1,0 +1,32 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@FtStereotype
+@ApplicationScoped
+public class StereotypeService {
+
+    private final AtomicInteger callCount = new AtomicInteger(0);
+
+    AtomicInteger getCallCount() {
+        return callCount;
+    }
+
+    void resetCallCount() {
+        callCount.set(0);
+    }
+
+    @Fallback(fallbackMethod = "fallback")
+    public String work() {
+        callCount.incrementAndGet();
+        throw new RuntimeException("transient failure");
+    }
+
+    String fallback() {
+        return "fallback";
+    }
+}

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>smallrye-fault-tolerance-testsuite-parent</artifactId>
         <groupId>io.smallrye</groupId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-testsuite-integration</artifactId>

--- a/testsuite/minimptel/pom.xml
+++ b/testsuite/minimptel/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-testsuite-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-minimptel</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>smallrye-fault-tolerance-parent</artifactId>
         <groupId>io.smallrye</groupId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-testsuite-parent</artifactId>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-testsuite-parent</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.11.1</version>
     </parent>
 
     <artifactId>smallrye-fault-tolerance-tck</artifactId>


### PR DESCRIPTION
Fixes #1274.

When `@Fallback` is at method level and other FT annotations arrive via a class-level `@Stereotype`, `FaultToleranceMethods` returns null for all of them. Neither `AnnotatedType.getAnnotation()` nor `Class.getAnnotation()` look inside `@Stereotype` meta-annotations.

The fix adds a private `findInStereotypes` helper that both the CDI and reflection paths delegate to when a direct lookup returns null. It handles nested stereotypes recursively.