### PR TITLE
fix annotation lookup when FT annotations come from a class-level stereotype

### DIFF
--- a/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceMethods.java
+++ b/implementation/fault-tolerance/src/main/java/io/smallrye/faulttolerance/config/FaultToleranceMethods.java
@@ -1,14 +1,20 @@
 package io.smallrye.faulttolerance.config;
 
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Inherited;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.enterprise.inject.Stereotype;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -80,7 +86,11 @@ public class FaultToleranceMethods {
             directlyPresent.add(annotationType);
             return cdiMethod.getAnnotation(annotationType);
         }
-        return cdiMethod.getDeclaringType().getAnnotation(annotationType);
+        A annotation = cdiMethod.getDeclaringType().getAnnotation(annotationType);
+        if (annotation == null) {
+            annotation = findInStereotypes(cdiMethod.getDeclaringType().getAnnotations(), annotationType);
+        }
+        return annotation;
     }
 
     // ---
@@ -139,9 +149,16 @@ public class FaultToleranceMethods {
     }
 
     private static <A extends Annotation> A getAnnotationFromClass(Class<?> clazz, Class<A> annotationType) {
+        // all Fault Tolerance annotations (in MP FT API and SRye FT API) are `@Inherited`,
+        // but stereotypes don't have to be
+        boolean notInherited = !annotationType.isAnnotationPresent(Inherited.class);
+
         while (clazz != null) {
             A annotation = clazz.getAnnotation(annotationType);
-            if (annotation != null) {
+            if (annotation == null) {
+                annotation = findInStereotypes(Arrays.asList(clazz.getAnnotations()), annotationType);
+            }
+            if (annotation != null || notInherited) {
                 return annotation;
             }
             clazz = clazz.getSuperclass();
@@ -196,5 +213,27 @@ public class FaultToleranceMethods {
             result.add(createMethodDescriptor(reflectiveMethod));
         }
         return result;
+    }
+
+    private static <A extends Annotation> A findInStereotypes(Collection<Annotation> annotations, Class<A> annotationType) {
+        Deque<Annotation> worklist = new ArrayDeque<>(annotations);
+        Set<Class<? extends Annotation>> seen = new HashSet<>();
+
+        while (!worklist.isEmpty()) {
+            Annotation annotation = worklist.removeFirst();
+            Class<? extends Annotation> type = annotation.annotationType();
+            if (!type.isAnnotationPresent(Stereotype.class)) {
+                continue;
+            }
+            if (!seen.add(type)) {
+                continue;
+            }
+            A found = type.getAnnotation(annotationType);
+            if (found != null) {
+                return found;
+            }
+            Collections.addAll(worklist, type.getAnnotations());
+        }
+        return null;
     }
 }

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ClassOverridesDirectStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ClassOverridesDirectStereotype.java
@@ -1,0 +1,11 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@MyStereotype
+@Retry(maxRetries = 5)
+@ApplicationScoped
+public class ClassOverridesDirectStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ClassOverridesDirectTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ClassOverridesDirectTransitiveStereotype.java
@@ -1,0 +1,11 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@MyTransitiveStereotype
+@Retry(maxRetries = 5)
+@ApplicationScoped
+public class ClassOverridesDirectTransitiveStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ClassOverridesInheritedStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ClassOverridesInheritedStereotype.java
@@ -1,0 +1,10 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Retry(maxRetries = 5)
+@ApplicationScoped
+public class ClassOverridesInheritedStereotype extends ServiceBaseWithStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ClassOverridesInheritedTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ClassOverridesInheritedTransitiveStereotype.java
@@ -1,0 +1,10 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Retry(maxRetries = 5)
+@ApplicationScoped
+public class ClassOverridesInheritedTransitiveStereotype extends ServiceBaseWithTransitiveStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesClassAndDirectStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesClassAndDirectStereotype.java
@@ -1,0 +1,18 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@MyStereotype
+@Retry(maxRetries = 5)
+@ApplicationScoped
+public class MethodOverridesClassAndDirectStereotype extends ServiceBase {
+    @Override
+    @Retry(maxRetries = 6)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        return super.hello();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesClassAndDirectTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesClassAndDirectTransitiveStereotype.java
@@ -1,0 +1,18 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@MyTransitiveStereotype
+@Retry(maxRetries = 5)
+@ApplicationScoped
+public class MethodOverridesClassAndDirectTransitiveStereotype extends ServiceBase {
+    @Override
+    @Retry(maxRetries = 6)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        return super.hello();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesClassAndInheritedStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesClassAndInheritedStereotype.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Retry(maxRetries = 5)
+@ApplicationScoped
+public class MethodOverridesClassAndInheritedStereotype extends ServiceBaseWithStereotype {
+    @Override
+    @Retry(maxRetries = 6)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        return super.hello();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesClassAndInheritedTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesClassAndInheritedTransitiveStereotype.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Retry(maxRetries = 5)
+@ApplicationScoped
+public class MethodOverridesClassAndInheritedTransitiveStereotype extends ServiceBaseWithTransitiveStereotype {
+    @Override
+    @Retry(maxRetries = 6)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        return super.hello();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesDirectStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesDirectStereotype.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@MyStereotype
+@ApplicationScoped
+public class MethodOverridesDirectStereotype extends ServiceBase {
+    @Override
+    @Retry(maxRetries = 6)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        return super.hello();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesDirectTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesDirectTransitiveStereotype.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@MyTransitiveStereotype
+@ApplicationScoped
+public class MethodOverridesDirectTransitiveStereotype extends ServiceBase {
+    @Override
+    @Retry(maxRetries = 6)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        return super.hello();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesInheritedStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesInheritedStereotype.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@ApplicationScoped
+public class MethodOverridesInheritedStereotype extends ServiceBaseWithStereotype {
+    @Override
+    @Retry(maxRetries = 6)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        return super.hello();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesInheritedTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MethodOverridesInheritedTransitiveStereotype.java
@@ -1,0 +1,16 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@ApplicationScoped
+public class MethodOverridesInheritedTransitiveStereotype extends ServiceBaseWithTransitiveStereotype {
+    @Override
+    @Retry(maxRetries = 6)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        return super.hello();
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MyNonInheritedStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MyNonInheritedStereotype.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Stereotype
+@Retry(maxRetries = 7)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MyNonInheritedStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MyNonInheritedTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MyNonInheritedTransitiveStereotype.java
@@ -1,0 +1,15 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.inject.Stereotype;
+
+@Stereotype
+@MyNonInheritedStereotype
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MyNonInheritedTransitiveStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MyStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MyStereotype.java
@@ -1,0 +1,19 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Stereotype
+@Retry(maxRetries = 4)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MyStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MyTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/MyTransitiveStereotype.java
@@ -1,0 +1,17 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.inject.Stereotype;
+
+@Stereotype
+@MyStereotype
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MyTransitiveStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NonInheritedOnlyDirectStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NonInheritedOnlyDirectStereotype.java
@@ -1,0 +1,8 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@MyNonInheritedStereotype
+@ApplicationScoped
+public class NonInheritedOnlyDirectStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NonInheritedOnlyDirectTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NonInheritedOnlyDirectTransitiveStereotype.java
@@ -1,0 +1,8 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@MyNonInheritedTransitiveStereotype
+@ApplicationScoped
+public class NonInheritedOnlyDirectTransitiveStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NonInheritedOnlyInheritedStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NonInheritedOnlyInheritedStereotype.java
@@ -1,0 +1,8 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+// the superclass has a stereotype, but that isn't inherited
+@ApplicationScoped
+public class NonInheritedOnlyInheritedStereotype extends ServiceBaseWithNonInheritedStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NonInheritedOnlyInheritedTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/NonInheritedOnlyInheritedTransitiveStereotype.java
@@ -1,0 +1,8 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+// the superclass has a stereotype, but that isn't inherited
+@ApplicationScoped
+public class NonInheritedOnlyInheritedTransitiveStereotype extends ServiceBaseWithNonInheritedTransitiveStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/OnlyDirectStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/OnlyDirectStereotype.java
@@ -1,0 +1,8 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@MyStereotype
+@ApplicationScoped
+public class OnlyDirectStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/OnlyDirectTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/OnlyDirectTransitiveStereotype.java
@@ -1,0 +1,8 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@MyTransitiveStereotype
+@ApplicationScoped
+public class OnlyDirectTransitiveStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/OnlyInheritedStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/OnlyInheritedStereotype.java
@@ -1,0 +1,7 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class OnlyInheritedStereotype extends ServiceBaseWithStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/OnlyInheritedTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/OnlyInheritedTransitiveStereotype.java
@@ -1,0 +1,7 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class OnlyInheritedTransitiveStereotype extends ServiceBaseWithTransitiveStereotype {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBase.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBase.java
@@ -1,0 +1,27 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+public abstract class ServiceBase {
+    private final AtomicInteger invocations = new AtomicInteger();
+
+    void reset() {
+        invocations.set(0);
+    }
+
+    int getInvocations() {
+        return invocations.get();
+    }
+
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        invocations.incrementAndGet();
+        throw new RuntimeException("simulated failure");
+    }
+
+    public String fallback() {
+        return "fallback";
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBaseWithNonInheritedStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBaseWithNonInheritedStereotype.java
@@ -1,0 +1,5 @@
+package io.smallrye.faulttolerance.stereotype;
+
+@MyNonInheritedStereotype
+public class ServiceBaseWithNonInheritedStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBaseWithNonInheritedTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBaseWithNonInheritedTransitiveStereotype.java
@@ -1,0 +1,5 @@
+package io.smallrye.faulttolerance.stereotype;
+
+@MyNonInheritedTransitiveStereotype
+public class ServiceBaseWithNonInheritedTransitiveStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBaseWithStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBaseWithStereotype.java
@@ -1,0 +1,5 @@
+package io.smallrye.faulttolerance.stereotype;
+
+@MyStereotype
+public class ServiceBaseWithStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBaseWithTransitiveStereotype.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/ServiceBaseWithTransitiveStereotype.java
@@ -1,0 +1,5 @@
+package io.smallrye.faulttolerance.stereotype;
+
+@MyTransitiveStereotype
+public class ServiceBaseWithTransitiveStereotype extends ServiceBase {
+}

--- a/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/StereotypeTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/faulttolerance/stereotype/StereotypeTest.java
@@ -1,0 +1,206 @@
+package io.smallrye.faulttolerance.stereotype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.faulttolerance.util.FaultToleranceBasicTest;
+
+@FaultToleranceBasicTest
+public class StereotypeTest {
+    @Inject
+    OnlyDirectStereotype onlyDirectStereotype;
+    @Inject
+    OnlyInheritedStereotype onlyInheritedStereotype;
+    @Inject
+    OnlyDirectTransitiveStereotype onlyDirectTransitiveStereotype;
+    @Inject
+    OnlyInheritedTransitiveStereotype onlyInheritedTransitiveStereotype;
+
+    @Inject
+    ClassOverridesDirectStereotype classOverridesDirectStereotype;
+    @Inject
+    ClassOverridesInheritedStereotype classOverridesInheritedStereotype;
+    @Inject
+    ClassOverridesDirectTransitiveStereotype classOverridesDirectTransitiveStereotype;
+    @Inject
+    ClassOverridesInheritedTransitiveStereotype classOverridesInheritedTransitiveStereotype;
+
+    @Inject
+    MethodOverridesDirectStereotype methodOverridesDirectStereotype;
+    @Inject
+    MethodOverridesInheritedStereotype methodOverridesInheritedStereotype;
+    @Inject
+    MethodOverridesDirectTransitiveStereotype methodOverridesDirectTransitiveStereotype;
+    @Inject
+    MethodOverridesInheritedTransitiveStereotype methodOverridesInheritedTransitiveStereotype;
+
+    @Inject
+    MethodOverridesClassAndDirectStereotype methodOverridesClassAndDirectStereotype;
+    @Inject
+    MethodOverridesClassAndInheritedStereotype methodOverridesClassAndInheritedStereotype;
+    @Inject
+    MethodOverridesClassAndDirectTransitiveStereotype methodOverridesClassAndDirectTransitiveStereotype;
+    @Inject
+    MethodOverridesClassAndInheritedTransitiveStereotype methodOverridesClassAndInheritedTransitiveStereotype;
+
+    @Inject
+    NonInheritedOnlyDirectStereotype nonInheritedOnlyDirectStereotype;
+    @Inject
+    NonInheritedOnlyInheritedStereotype nonInheritedOnlyInheritedStereotype;
+    @Inject
+    NonInheritedOnlyDirectTransitiveStereotype nonInheritedOnlyDirectTransitiveStereotype;
+    @Inject
+    NonInheritedOnlyInheritedTransitiveStereotype nonInheritedOnlyInheritedTransitiveStereotype;
+
+    @BeforeEach
+    void reset() {
+        onlyDirectStereotype.reset();
+        onlyInheritedStereotype.reset();
+        onlyDirectTransitiveStereotype.reset();
+        onlyInheritedTransitiveStereotype.reset();
+
+        classOverridesDirectStereotype.reset();
+        classOverridesInheritedStereotype.reset();
+        classOverridesDirectTransitiveStereotype.reset();
+        classOverridesInheritedTransitiveStereotype.reset();
+
+        methodOverridesDirectStereotype.reset();
+        methodOverridesInheritedStereotype.reset();
+        methodOverridesDirectTransitiveStereotype.reset();
+        methodOverridesInheritedTransitiveStereotype.reset();
+
+        methodOverridesClassAndDirectStereotype.reset();
+        methodOverridesClassAndInheritedStereotype.reset();
+        methodOverridesClassAndDirectTransitiveStereotype.reset();
+        methodOverridesClassAndInheritedTransitiveStereotype.reset();
+
+        nonInheritedOnlyDirectStereotype.reset();
+        nonInheritedOnlyInheritedStereotype.reset();
+        nonInheritedOnlyDirectTransitiveStereotype.reset();
+        nonInheritedOnlyInheritedTransitiveStereotype.reset();
+    }
+
+    @Test
+    void onlyDirectStereotype() {
+        assertThat(onlyDirectStereotype.hello()).isEqualTo("fallback");
+        assertThat(onlyDirectStereotype.getInvocations()).isEqualTo(5);
+    }
+
+    @Test
+    void onlyInheritedStereotype() {
+        assertThat(onlyInheritedStereotype.hello()).isEqualTo("fallback");
+        assertThat(onlyInheritedStereotype.getInvocations()).isEqualTo(5);
+    }
+
+    @Test
+    void onlyDirectTransitiveStereotype() {
+        assertThat(onlyDirectTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(onlyDirectTransitiveStereotype.getInvocations()).isEqualTo(5);
+    }
+
+    @Test
+    void onlyInheritedTransitiveStereotype() {
+        assertThat(onlyInheritedTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(onlyInheritedTransitiveStereotype.getInvocations()).isEqualTo(5);
+    }
+
+    @Test
+    void classOverridesDirectStereotype() {
+        assertThat(classOverridesDirectStereotype.hello()).isEqualTo("fallback");
+        assertThat(classOverridesDirectStereotype.getInvocations()).isEqualTo(6);
+    }
+
+    @Test
+    void classOverridesInheritedStereotype() {
+        assertThat(classOverridesInheritedStereotype.hello()).isEqualTo("fallback");
+        assertThat(classOverridesInheritedStereotype.getInvocations()).isEqualTo(6);
+    }
+
+    @Test
+    void classOverridesDirectTransitiveStereotype() {
+        assertThat(classOverridesDirectTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(classOverridesDirectTransitiveStereotype.getInvocations()).isEqualTo(6);
+    }
+
+    @Test
+    void classOverridesInheritedTransitiveStereotype() {
+        assertThat(classOverridesInheritedTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(classOverridesInheritedTransitiveStereotype.getInvocations()).isEqualTo(6);
+    }
+
+    @Test
+    void methodOverridesDirectStereotype() {
+        assertThat(methodOverridesDirectStereotype.hello()).isEqualTo("fallback");
+        assertThat(methodOverridesDirectStereotype.getInvocations()).isEqualTo(7);
+    }
+
+    @Test
+    void methodOverridesInheritedStereotype() {
+        assertThat(methodOverridesInheritedStereotype.hello()).isEqualTo("fallback");
+        assertThat(methodOverridesInheritedStereotype.getInvocations()).isEqualTo(7);
+    }
+
+    @Test
+    void methodOverridesDirectTransitiveStereotype() {
+        assertThat(methodOverridesDirectTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(methodOverridesDirectTransitiveStereotype.getInvocations()).isEqualTo(7);
+    }
+
+    @Test
+    void methodOverridesInheritedTransitiveStereotype() {
+        assertThat(methodOverridesInheritedTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(methodOverridesInheritedTransitiveStereotype.getInvocations()).isEqualTo(7);
+    }
+
+    @Test
+    void methodOverridesClassAndDirectStereotype() {
+        assertThat(methodOverridesClassAndDirectStereotype.hello()).isEqualTo("fallback");
+        assertThat(methodOverridesClassAndDirectStereotype.getInvocations()).isEqualTo(7);
+    }
+
+    @Test
+    void methodOverridesClassAndInheritedStereotype() {
+        assertThat(methodOverridesClassAndInheritedStereotype.hello()).isEqualTo("fallback");
+        assertThat(methodOverridesClassAndInheritedStereotype.getInvocations()).isEqualTo(7);
+    }
+
+    @Test
+    void methodOverridesClassAndDirectTransitiveStereotype() {
+        assertThat(methodOverridesClassAndDirectTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(methodOverridesClassAndDirectTransitiveStereotype.getInvocations()).isEqualTo(7);
+    }
+
+    @Test
+    void methodOverridesClassAndInheritedTransitiveStereotype() {
+        assertThat(methodOverridesClassAndInheritedTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(methodOverridesClassAndInheritedTransitiveStereotype.getInvocations()).isEqualTo(7);
+    }
+
+    @Test
+    void nonInheritedOnlyDirectStereotype() {
+        assertThat(nonInheritedOnlyDirectStereotype.hello()).isEqualTo("fallback");
+        assertThat(nonInheritedOnlyDirectStereotype.getInvocations()).isEqualTo(8);
+    }
+
+    @Test
+    void nonInheritedOnlyInheritedStereotype() {
+        assertThat(nonInheritedOnlyInheritedStereotype.hello()).isEqualTo("fallback");
+        assertThat(nonInheritedOnlyInheritedStereotype.getInvocations()).isEqualTo(1);
+    }
+
+    @Test
+    void nonInheritedOnlyDirectTransitiveStereotype() {
+        assertThat(nonInheritedOnlyDirectTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(nonInheritedOnlyDirectTransitiveStereotype.getInvocations()).isEqualTo(8);
+    }
+
+    @Test
+    void nonInheritedOnlyInheritedTransitiveStereotype() {
+        assertThat(nonInheritedOnlyInheritedTransitiveStereotype.hello()).isEqualTo("fallback");
+        assertThat(nonInheritedOnlyInheritedTransitiveStereotype.getInvocations()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Fixes #1274.

When @Fallback is at method level and other FT annotations arrive via a class-level @Stereotype, FaultToleranceMethods returns null for all of them. Neither AnnotatedType.getAnnotation() nor Class.getAnnotation() look inside @Stereotype meta-annotations.

The fix adds a private findInStereotypes helper that both the CDI and reflection paths delegate to when a direct lookup returns null. It handles nested stereotypes recursively and prevents infinite loops using a visited set.

**CDI vs reflection path note:** The CDI path searches getDeclaringType() directly, while the reflection path walks the superclass hierarchy explicitly. Both are correct: stereotypes marked with @Inherited are visible on subclasses via Java reflection even when a subclass overrides the method, so the CDI path finds inherited stereotypes without walking the hierarchy manually.

**Tests:** 16 tests covering a 4×4 matrix (all using @Retry):
- Axis 1 (annotation placement): stereotype only / class overrides stereotype / method overrides stereotype / class+method override stereotype
- Axis 2 (stereotype discovery): direct on class / inherited from superclass / nested stereotype on class / nested stereotype inherited from superclass

Reproduction: https://github.com/TelesNascimento25/smallrye-ft-stereotype-fallback